### PR TITLE
Configures initial setup for gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var gulp = require('gulp');
+var sample = require('./tasks/sample');
+
+gulp.task('sample', sample.run());
+gulp.task('default', ['sample']);

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://jira.rax.io/secure/RapidBoard.jspa?rapidView=3462&projectKey=MNRVA&view=planning&selectedIssue=MNRVA-18&epics=visible"
   },
-  "homepage": "https://github.com/racker/Minerva#readme"
+  "homepage": "https://github.com/racker/Minerva#readme",
+  "devDependencies": {
+    "gulp": "3.9.1"
+  }
 }

--- a/tasks/sample.js
+++ b/tasks/sample.js
@@ -1,0 +1,5 @@
+function run () {
+    console.log('A simple sample.');
+};
+
+module.exports.run = run;

--- a/tasks/sample.js
+++ b/tasks/sample.js
@@ -1,5 +1,6 @@
 function run () {
-    console.log('A simple sample.');
+    // A sample task for showing how to pipe
+    // tasks to the main gulpfile
 };
 
 module.exports.run = run;


### PR DESCRIPTION
**JIRA**: https://jira.rax.io/browse/MNRVA-7

**Description**: 
Sets up gulp as our task runner of choice. Notice that each individual task will be broken down into individual files located in the tasks folder. This will help combat long running gulpfiles. I have provided a sample task to show how that pipes through.

**Testing**: 
Simply run `gulp` and it will execute the default task.