### PR TITLE
Adds a POC graph for live metrics data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,8 +2276,7 @@
     "commander": {
       "version": "2.17.1",
       "resolved": "http://registry.ui.encore.rackspace.com:4873/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -2642,6 +2641,270 @@
       "resolved": "http://registry.ui.encore.rackspace.com:4873/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
+    },
+    "d3": {
+      "version": "5.7.0",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3/-/d3-5.7.0.tgz",
+      "integrity": "sha512-8KEIfx+dFm8PlbJN9PI0suazrZ41QcaAufsKE9PRcqYPWLngHIyWJZX96n6IQKePGgeSu0l7rtlueSSNq8Zc3g==",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-axis": "1.0.12",
+        "d3-brush": "1.0.6",
+        "d3-chord": "1.0.6",
+        "d3-collection": "1.0.7",
+        "d3-color": "1.2.3",
+        "d3-contour": "1.3.2",
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-dsv": "1.0.10",
+        "d3-ease": "1.0.5",
+        "d3-fetch": "1.1.2",
+        "d3-force": "1.1.2",
+        "d3-format": "1.3.2",
+        "d3-geo": "1.11.1",
+        "d3-hierarchy": "1.1.8",
+        "d3-interpolate": "1.3.2",
+        "d3-path": "1.0.7",
+        "d3-polygon": "1.0.5",
+        "d3-quadtree": "1.0.5",
+        "d3-random": "1.1.2",
+        "d3-scale": "2.1.2",
+        "d3-scale-chromatic": "1.3.3",
+        "d3-selection": "1.3.2",
+        "d3-shape": "1.2.2",
+        "d3-time": "1.0.10",
+        "d3-time-format": "2.1.3",
+        "d3-timer": "1.0.9",
+        "d3-transition": "1.1.3",
+        "d3-voronoi": "1.1.4",
+        "d3-zoom": "1.7.3"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-axis": {
+      "version": "1.0.12",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-axis/-/d3-axis-1.0.12.tgz",
+      "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
+    },
+    "d3-brush": {
+      "version": "1.0.6",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-brush/-/d3-brush-1.0.6.tgz",
+      "integrity": "sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==",
+      "requires": {
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-transition": "1.1.3"
+      }
+    },
+    "d3-chord": {
+      "version": "1.0.6",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-chord/-/d3-chord-1.0.6.tgz",
+      "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-path": "1.0.7"
+      }
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.2.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-color/-/d3-color-1.2.3.tgz",
+      "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw=="
+    },
+    "d3-contour": {
+      "version": "1.3.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-contour/-/d3-contour-1.3.2.tgz",
+      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
+      "requires": {
+        "d3-array": "1.2.4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "1.0.5",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
+      "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
+    },
+    "d3-drag": {
+      "version": "1.2.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-drag/-/d3-drag-1.2.3.tgz",
+      "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
+      "requires": {
+        "d3-dispatch": "1.0.5",
+        "d3-selection": "1.3.2"
+      }
+    },
+    "d3-dsv": {
+      "version": "1.0.10",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-dsv/-/d3-dsv-1.0.10.tgz",
+      "integrity": "sha512-vqklfpxmtO2ZER3fq/B33R/BIz3A1PV0FaZRuFM8w6jLo7sUX1BZDh73fPlr0s327rzq4H6EN1q9U+eCBCSN8g==",
+      "requires": {
+        "commander": "2.17.1",
+        "iconv-lite": "0.4.23",
+        "rw": "1.3.3"
+      }
+    },
+    "d3-ease": {
+      "version": "1.0.5",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-ease/-/d3-ease-1.0.5.tgz",
+      "integrity": "sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ=="
+    },
+    "d3-fetch": {
+      "version": "1.1.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-fetch/-/d3-fetch-1.1.2.tgz",
+      "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
+      "requires": {
+        "d3-dsv": "1.0.10"
+      }
+    },
+    "d3-force": {
+      "version": "1.1.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-force/-/d3-force-1.1.2.tgz",
+      "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
+      "requires": {
+        "d3-collection": "1.0.7",
+        "d3-dispatch": "1.0.5",
+        "d3-quadtree": "1.0.5",
+        "d3-timer": "1.0.9"
+      }
+    },
+    "d3-format": {
+      "version": "1.3.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
+    "d3-geo": {
+      "version": "1.11.1",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-geo/-/d3-geo-1.11.1.tgz",
+      "integrity": "sha512-GsG7x9G9sykseLviOVSJ3h5yjw0ItLopOtuDQKUt1TRklEegCw5WAmnIpYYiCkSH/QgUMleAeE2xZK38Qb+1+Q==",
+      "requires": {
+        "d3-array": "1.2.4"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.8",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
+      "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
+    },
+    "d3-interpolate": {
+      "version": "1.3.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
+      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "requires": {
+        "d3-color": "1.2.3"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.7",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-path/-/d3-path-1.0.7.tgz",
+      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA=="
+    },
+    "d3-polygon": {
+      "version": "1.0.5",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-polygon/-/d3-polygon-1.0.5.tgz",
+      "integrity": "sha512-RHhh1ZUJZfhgoqzWWuRhzQJvO7LavchhitSTHGu9oj6uuLFzYZVeBzaWTQ2qSO6bz2w55RMoOCf0MsLCDB6e0w=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.5",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+      "integrity": "sha512-U2tjwDFbZ75JRAg8A+cqMvqPg1G3BE7UTJn3h8DHjY/pnsAfWdbJKgyfcy7zKjqGtLAmI0q8aDSeG1TVIKRaHQ=="
+    },
+    "d3-random": {
+      "version": "1.1.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-random/-/d3-random-1.1.2.tgz",
+      "integrity": "sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ=="
+    },
+    "d3-scale": {
+      "version": "2.1.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-scale/-/d3-scale-2.1.2.tgz",
+      "integrity": "sha512-bESpd64ylaKzCDzvULcmHKZTlzA/6DGSVwx7QSDj/EnX9cpSevsdiwdHFYI9ouo9tNBbV3v5xztHS2uFeOzh8Q==",
+      "requires": {
+        "d3-array": "1.2.4",
+        "d3-collection": "1.0.7",
+        "d3-format": "1.3.2",
+        "d3-interpolate": "1.3.2",
+        "d3-time": "1.0.10",
+        "d3-time-format": "2.1.3"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "1.3.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
+      "integrity": "sha512-BWTipif1CimXcYfT02LKjAyItX5gKiwxuPRgr4xM58JwlLocWbjPLI7aMEjkcoOQXMkYsmNsvv3d2yl/OKuHHw==",
+      "requires": {
+        "d3-color": "1.2.3",
+        "d3-interpolate": "1.3.2"
+      }
+    },
+    "d3-selection": {
+      "version": "1.3.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-selection/-/d3-selection-1.3.2.tgz",
+      "integrity": "sha512-OoXdv1nZ7h2aKMVg3kaUFbLLK5jXUFAMLD/Tu5JA96mjf8f2a9ZUESGY+C36t8R1WFeWk/e55hy54Ml2I62CRQ=="
+    },
+    "d3-shape": {
+      "version": "1.2.2",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-shape/-/d3-shape-1.2.2.tgz",
+      "integrity": "sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==",
+      "requires": {
+        "d3-path": "1.0.7"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.10",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-time/-/d3-time-1.0.10.tgz",
+      "integrity": "sha512-hF+NTLCaJHF/JqHN5hE8HVGAXPStEq6/omumPE/SxyHVrR7/qQxusFDo0t0c/44+sCGHthC7yNGFZIEgju0P8g=="
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "requires": {
+        "d3-time": "1.0.10"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.9",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-timer/-/d3-timer-1.0.9.tgz",
+      "integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg=="
+    },
+    "d3-transition": {
+      "version": "1.1.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-transition/-/d3-transition-1.1.3.tgz",
+      "integrity": "sha512-tEvo3qOXL6pZ1EzcXxFcPNxC/Ygivu5NoBY6mbzidATAeML86da+JfVIUzon3dNM6UX6zjDx+xbYDmMVtTSjuA==",
+      "requires": {
+        "d3-color": "1.2.3",
+        "d3-dispatch": "1.0.5",
+        "d3-ease": "1.0.5",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-timer": "1.0.9"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
+    "d3-zoom": {
+      "version": "1.7.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/d3-zoom/-/d3-zoom-1.7.3.tgz",
+      "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
+      "requires": {
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-transition": "1.1.3"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -5384,7 +5647,6 @@
       "version": "0.4.23",
       "resolved": "http://registry.ui.encore.rackspace.com:4873/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -9004,6 +9266,11 @@
         "aproba": "1.2.0"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "http://registry.ui.encore.rackspace.com:4873/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "rxjs": {
       "version": "6.3.3",
       "resolved": "http://registry.ui.encore.rackspace.com:4873/rxjs/-/rxjs-6.3.3.tgz",
@@ -9030,8 +9297,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "http://registry.ui.encore.rackspace.com:4873/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "@angular/router": "~7.0.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
     "core-js": "^2.5.4",
+    "d3": "^5.7.0",
+    "d3-path": "^1.0.7",
+    "d3-shape": "^1.2.2",
     "helix-ui": "^0.14.0",
     "rxjs": "~6.3.3",
     "zone.js": "~0.8.26"

--- a/src/app/poc-data-call/poc-data-call.component.html
+++ b/src/app/poc-data-call/poc-data-call.component.html
@@ -1,3 +1,2 @@
-<p>
-  poc-data-call works!
-</p>
+<svg id='poc-graph'></svg>
+

--- a/src/app/poc-data-call/poc-data-call.component.ts
+++ b/src/app/poc-data-call/poc-data-call.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { PocApiCallService } from '../poc-api-call.service';
+import * as d3 from 'd3';
 
 @Component({
   selector: 'app-poc-data-call',
@@ -8,16 +9,80 @@ import { PocApiCallService } from '../poc-api-call.service';
 })
 export class PocDataCallComponent implements OnInit {
 
+  marshalledData = [];
+
   constructor( private apiCall:PocApiCallService ) { 
     
   }
 
   ngOnInit() {
+  }
+
+  ngAfterContentInit() {
     this.fetchData();
   }
 
   fetchData(){
     this.apiCall.post({ "queryString":  "select * from agent_cpu where time > now() - 5m" })
-    .subscribe(response => console.log(response));
+    .subscribe(response => this.dataMarshaller(response));
+  }
+
+  visualize() {
+
+    // Setup the margins and height, width
+    var margin = { top: 30, right: 20, bottom: 30, left: 50 };
+    const height = 200 - margin.top - margin.bottom;
+    const width = 600 - margin.left - margin.right;
+
+    // Create the line
+    var calculatedLine = d3.line()
+    .y(function(data:any, index:number){
+      return data.cpu_max_usage;
+    })
+    .x(function(data:any, index:number){
+      return index * 10;
+    })
+
+    // Setup the svg element in the DOM
+    var svg = d3.select('svg')
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append('g')
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+    // Create the path to the line in the svg element
+    svg.append('path')
+    .attr('d', calculatedLine(this.marshalledData))
+    .attr('class', 'line')
+    .style('stroke-width', 2)
+    .style('stroke', 'orange')
+    .style('fill', 'none');
+  
+    // Scale the graph to the dimensions of the svg
+    var chartProps = {};
+    chartProps['x'] = d3.scaleLinear().range([0, width]);
+    chartProps['y'] = d3.scaleLinear().range([height, 0]);
+
+    var xAxis = d3.axisBottom(chartProps['x']);
+    var yAxis = d3.axisLeft(chartProps['y']);
+    
+    // Add the X Axis
+    svg.append("g")
+      .attr("class", "x axis")
+      .attr("transform", "translate(0," + height + ")")
+      .call(xAxis);
+
+    // Add the Y Axis
+    svg.append("g")
+      .attr("class", "y axis")
+      .call(yAxis);
+  }
+
+  dataMarshaller(data: any) {
+    for (let index in data[0].valuesCollection) {
+      this.marshalledData.push({ time: data[0].valuesCollection[index][0], cpu_max_usage: data[0].valuesCollection[index][8] });
+    }
+  
+    this.visualize();
   }
 }


### PR DESCRIPTION
**JIRA**: https://jira.rax.io/browse/MNRVA-21

**Description**:
Uses d3.js to visualize live metrics v2 data.  This graph is a POC and is throw away. Do not pay attention to graph labels as I didn't want to spend too much time flushing that out since it is throw away anyways.  There is also no automated testing for this by design

**Test**:
Run `ng serve` and view the graph

**Screenshot**

![rackspace_intelligence](https://user-images.githubusercontent.com/1617443/48438417-8e402f00-e749-11e8-9020-a06466d32137.png)
