### PR TITLE
Temp fix for package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,7 +893,7 @@
       "dev": true,
       "requires": {
         "@compodoc/compodoc": "1.1.6",
-        "event-stream": "3.3.6",
+        "event-stream": "4.0.0",
         "plugin-error": "1.0.1",
         "through2": "2.0.5"
       }


### PR DESCRIPTION
## JIRA:
N/A See ticket here - https://jira.rax.io/browse/MNRVA-XXXX

 ## Description:
This is a Temp fix so that we know to correctly identify the non malicious version of  `event-stream`. The problem is with `@gulp-compodoc` usage of this outdated dependency, I have opened an issue with the gulp-compudoc so that they update their dependency.
https://github.com/compodoc/gulp-compodoc/issues/8

 ## Testing:

 ## Screenshots:
(if applicable)