### PR TITLE
Adds pilot nav element and PORTAL_DATA service

### DIFF
--- a/src/app/app.module.mock.ts
+++ b/src/app/app.module.mock.ts
@@ -1,0 +1,6 @@
+export class AppModuleMock {
+    mock = {
+        domainId: "833544", 
+        tenants: ["cloud:833544"]
+    }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,13 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA, APP_INITIALIZER } from '@angular/core';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HttpClientModule } from '@angular/common/http';
 import { localStorageProviders } from '@ngx-pwa/local-storage';
+import { environment } from 'src/environments/environment';
 
 import { PocDataCallComponent } from './poc-data-call/poc-data-call.component';
+import { AppModuleMock } from './app.module.mock';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
@@ -20,9 +22,22 @@ import { PocDataCallComponent } from './poc-data-call/poc-data-call.component';
   ],
   exports: [],
   providers: [
-    localStorageProviders({ prefix: 'intelligence' })
+    localStorageProviders({ prefix: 'intelligence' }),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: portalData,
+      multi: true,
+      deps: []
+    }
   ],
   bootstrap: [ AppComponent ]
 })
 
 export class AppModule {}
+
+export function portalData(): any {
+  if (!environment.production) {
+    Window['PORTAL_DATA'] = new AppModuleMock().mock
+  }
+  return () => {};
+}

--- a/src/app/poc-api-call.service.mock.ts
+++ b/src/app/poc-api-call.service.mock.ts
@@ -1,5 +1,3 @@
-import { Mock } from "protractor/built/driverProviders";
-
 export class PocApiCallMockService {
     mock = [ 
         {

--- a/src/app/portal-data.service.spec.ts
+++ b/src/app/portal-data.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PortalDataService } from './portal-data.service';
+import { AppModuleMock } from './app.module.mock';
+
+Window['PORTAL_DATA'] = new AppModuleMock().mock
+
+describe('PortalDataService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: PortalDataService = TestBed.get(PortalDataService);
+    expect(service).toBeTruthy();
+  });
+
+  it('should have a domian id', () => {
+    const service: PortalDataService = TestBed.get(PortalDataService);
+    expect(service.domainId).toEqual('833544');
+  })
+});

--- a/src/app/portal-data.service.ts
+++ b/src/app/portal-data.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PortalDataService {
+  
+  domainId: string;
+  userId: string;
+  username: string;
+  tenants: [];
+
+  constructor() { 
+    this.domainId = Window['PORTAL_DATA'].domainId || null;
+    this.userId = Window['PORTAL_DATA'].userId || null;
+    this.username = Window['PORTAL_DATA'].username || null;
+    this.tenants = Window['PORTAL_DATA'].tenants || null;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"><!-- lang is necessary for screen reader compatibility -->
+<html lang="en" id="app"><!-- lang is necessary for screen reader compatibility -->
 <head>
   <base href='/'>
   <title>Rackspace Intelligence</title>
@@ -20,9 +20,10 @@
 
   <header id="head">
     <!-- Eyebrow Goes Here -->
+    <pilot-nav></pilot-nav>
   </header>
 
-  <div id="app">
+  <div>
       <div id="stage">
         <nav id="nav" class="hxNav">
             <!-- Product Navigation -->


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-31

 ## Description:
Turns out that pilot will be injected for us by the portal platform. It will use `<pilot-nav></pilot-nav>` as the selector. So all we really need to do is just have that on the index page. Locally we won't need to have pilot there so we will be good to go.  Also portal provides an object with account specifics, `Window['PORTAL_DATA']`

 ## Testing:
Only the to test here is the portal data service.  Run `npm test` to see the tests run.

 ## Screenshots:
(if applicable)