### PR TITLE
Adds a logging service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { environment } from 'src/environments/environment';
 
 import { PocDataCallComponent } from './poc-data-call/poc-data-call.component';
 import { AppModuleMock } from './app.module.mock';
+import { LoggingService } from './logging.service';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
@@ -28,6 +29,12 @@ import { AppModuleMock } from './app.module.mock';
       useFactory: portalData,
       multi: true,
       deps: []
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: logger,
+      multi: true,
+      deps: []
     }
   ],
   bootstrap: [ AppComponent ]
@@ -38,6 +45,16 @@ export class AppModule {}
 export function portalData(): any {
   if (!environment.production) {
     Window['PORTAL_DATA'] = new AppModuleMock().mock
+  }
+  return () => {};
+}
+
+export function logger(): any {
+  var logger = new LoggingService();
+  // if we don't currently have a log level set
+  // set the level to a default of error
+  if (!logger.getLevel()){
+    logger.setLevel(logger.logLevels.error);
   }
   return () => {};
 }

--- a/src/app/log-levels.enum.ts
+++ b/src/app/log-levels.enum.ts
@@ -1,0 +1,11 @@
+/**
+ * @name LogLevels
+ * @description
+ * Enum for setting the log levels of the LoggerService
+ */
+export enum LogLevels {
+    debug = 0,
+    info = 1,
+    warning = 2,
+    error = 3
+}

--- a/src/app/logging.service.spec.ts
+++ b/src/app/logging.service.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoggingService } from './logging.service';
+
+describe('LoggingService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: LoggingService = TestBed.get(LoggingService);
+    expect(service).toBeTruthy();
+  });
+
+  it('should set the log level', () => {
+    const service: LoggingService = TestBed.get(LoggingService);
+    service.setLevel(0);
+    expect(localStorage.getItem('LOG_LEVEL')).toEqual('0');
+  });
+
+  it('should get the log level', () => {
+    const service: LoggingService = TestBed.get(LoggingService);
+    var level = service.getLevel();
+    expect(level).toEqual('0');
+  });
+
+  it('should log a message to the console', () => {
+    const service: LoggingService = TestBed.get(LoggingService);
+    var consoleSpy = spyOn(console, 'log');
+    service.log('test', 1);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/logging.service.ts
+++ b/src/app/logging.service.ts
@@ -27,6 +27,7 @@ export class LoggingService {
   localStorage: LocalStorage;
 
   constructor() {
+    this.logLevel = localStorage.getItem('LOG_LEVEL');
   }
 
   /**
@@ -42,6 +43,7 @@ export class LoggingService {
    * loggingService.setLeve(LogLevels.info);
    */
   setLevel(logLevel: LogLevels) {
+    this.logLevel = logLevel;
     localStorage.setItem('LOG_LEVEL', logLevel.toString())
   }
 
@@ -73,7 +75,7 @@ export class LoggingService {
    * LoggingService.log({ message: 'some message': data: someDataObj }, LogLevels.info);
    */
   log(message: any, logLevel: LogLevels): void {
-    var level = localStorage.getItem('LOG_LEVEL');
+    var level = this.logLevel;
     if (logLevel >= parseInt(level)){
       console.log({ level: LogLevels[logLevel], message: message });
     }

--- a/src/app/logging.service.ts
+++ b/src/app/logging.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+import { LogLevels } from './log-levels.enum';
+import { LocalStorage } from '@ngx-pwa/local-storage';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+/**
+ * @name LoggingService
+ * @description
+ * A service for logging messages to the console. There are multiple log levels.
+ * They are, in order:
+ * 0. debug
+ * 1. info
+ * 2. warning
+ * 3. error
+ * 
+ * This uses local storage to keep track of the current log level.
+ * To change the log level, so that you may see different levels of messages,
+ * simply alter the LOG_LEVEL value in local storage using browser dev tools.
+ */
+export class LoggingService {
+
+  logLevel = null;
+  logLevels = LogLevels;
+  localStorage: LocalStorage;
+
+  constructor() {
+  }
+
+  /**
+   * @name LoggingService.setLevel
+   * @param {LogLevels} logLevel Enum of the different log levels
+   * @description
+   * Sets the log level in local storage
+   * @example
+   * var loggingService = new LoggingService();
+   * // Use either an int
+   * loggingService.setLevel(1);
+   * // Or you can use the enum
+   * loggingService.setLeve(LogLevels.info);
+   */
+  setLevel(logLevel: LogLevels) {
+    localStorage.setItem('LOG_LEVEL', logLevel.toString())
+  }
+
+  /**
+   * @name LoggingService.getLevel
+   * @description
+   * Gets the current level set in local storage
+   * @example
+   * var loggingService = new LoggingService();
+   * loggingService.getLevel();
+   */
+  getLevel() {
+    return localStorage.getItem('LOG_LEVEL');
+  }
+
+  /**
+   * @name LoggingService.log
+   * @description
+   * Logs a message to the console based on log level. The important thing to note here
+   * is that messages will only be logged to a specific, specified, level.  If the set level is
+   * greater than the level of the message it will not show up in the console.
+   * @param {any} message object that will represent the message of the log 
+   * @param {LogLevels} logLevel the level at which you would like the message to be logged to
+   * @example
+   * var loggingService = new LoggingService();
+   * // Sending a string
+   * loggingService.log('A message to the console', LogLevels.info);
+   * // Sending an object
+   * LoggingService.log({ message: 'some message': data: someDataObj }, LogLevels.info);
+   */
+  log(message: any, logLevel: LogLevels): void {
+    var level = localStorage.getItem('LOG_LEVEL');
+    if (logLevel >= parseInt(level)){
+      console.log({ level: LogLevels[logLevel], message: message });
+    }
+  }
+}

--- a/src/app/poc-data-call/poc-data-call.component.ts
+++ b/src/app/poc-data-call/poc-data-call.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { PocApiCallService } from '../poc-api-call.service';
 import * as d3 from 'd3';
+import { LoggingService } from '../logging.service';
 
 @Component({
   selector: 'app-poc-data-call',
@@ -10,12 +11,14 @@ import * as d3 from 'd3';
 export class PocDataCallComponent implements OnInit {
 
   marshalledData = [];
+  logger = new LoggingService();
 
   constructor( private apiCall:PocApiCallService ) { 
-    
+
   }
 
   ngOnInit() {
+    
   }
 
   ngAfterContentInit() {
@@ -23,6 +26,7 @@ export class PocDataCallComponent implements OnInit {
   }
 
   fetchData(){
+    this.logger.log('Fetching data', this.logger.logLevels.info);
     this.apiCall.post({ "queryString":  "select * from agent_cpu where time > now() - 5m" })
     .subscribe(response => this.dataMarshaller(response));
   }
@@ -79,10 +83,11 @@ export class PocDataCallComponent implements OnInit {
   }
 
   dataMarshaller(data: any) {
+    this.logger.log({ message: 'returned data', data: data }, 1);
     for (let index in data[0].valuesCollection) {
       this.marshalledData.push({ time: data[0].valuesCollection[index][0], cpu_max_usage: data[0].valuesCollection[index][8] });
     }
-  
+    this.logger.log('Finished marshalling data', 1);
     this.visualize();
   }
 }

--- a/src/app/poc-data-call/poc-data-call.component.ts
+++ b/src/app/poc-data-call/poc-data-call.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { PocApiCallService } from '../poc-api-call.service';
 import * as d3 from 'd3';
 import { LoggingService } from '../logging.service';


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-28

 ## Description:
Turns out that WinstonJs does not support in browser logging. It is meant for back end node applications. It was easy enough to just create a logging service to meet our needs.

 ## Testing:
Run the application `npm start`
Then play around with setting the `LOG_LEVEL` in local storage.
Observe expected behavior in the console.

 ## Screenshots:
(if applicable)