### PR TITLE
sets up proxy to dev.i.rax.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ This  will install all the application and developer dependencies into your `nod
 npm install
 ```
 
+## Setup the proxy
+
+In order to run the application locally you will need to add the following to your `/etc/hosts` file
+
+```
+0.0.0.0 dev.i.rax.io
+```
+
 ## Run The App
 
 Running the application is quite simple, but there are a few options for us to take a look at

--- a/angular.json
+++ b/angular.json
@@ -72,7 +72,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "minerva:build"
+            "browserTarget": "minerva:build",
+            "host": "dev.i.rax.io"
           },
           "configurations": {
             "production": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/racker/Minerva#readme",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --public-host dev.i.rax.io",
     "start-mock": "ng serve -c mock",
     "build": "ng build --watch",
     "build-mock": "ng build --watch -c mock",


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-130

 ## Description:

Adds a proxy for local development so that we can point the browser to `dev.i.rax.io:4200`.  This should allow for the ability to login to the application locally and have ADFS point to our local application.

 ## Testing:

Follow the proxy setup instructions on the readme file

run `npm start` and navigate to `dev.i.rax.io`

 ## Screenshots:
(if applicable)