### PR TITLE
add global error handler + server error interceptor

### DIFF
--- a/src/app/_interceptors/server-error.interceptor.ts
+++ b/src/app/_interceptors/server-error.interceptor.ts
@@ -13,7 +13,9 @@ export class ServerErrorInterceptor implements HttpInterceptor {
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
     return next.handle(request).pipe(
-      retry(1),
+      // TODO: Determine if a retry should be placed here or elsewhere
+      // should a request fail
+      // retry(1),
       catchError((error: HttpErrorResponse) => {
           return throwError(error);
       })

--- a/src/app/_interceptors/server-error.interceptor.ts
+++ b/src/app/_interceptors/server-error.interceptor.ts
@@ -1,0 +1,22 @@
+
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent, HttpRequest, HttpHandler,
+  HttpInterceptor, HttpErrorResponse
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { retry, catchError } from 'rxjs/operators';
+
+@Injectable()
+export class ServerErrorInterceptor implements HttpInterceptor {
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    return next.handle(request).pipe(
+      retry(1),
+      catchError((error: HttpErrorResponse) => {
+          return throwError(error);
+      })
+    );
+  }
+}

--- a/src/app/_services/error.service.spec.ts
+++ b/src/app/_services/error.service.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { ErrorService } from './error.service';
+import { HttpErrorResponse } from '@angular/common/http';
+
+describe('ErrorService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ErrorService = TestBed.get(ErrorService);
+    expect(service).toBeTruthy();
+  });
+
+  it('should execute getClientErrorService', () => {
+    const service: ErrorService = TestBed.get(ErrorService);
+    const error = new Error('basic Error');
+    expect(service.getClientErrorMessage(error)).toEqual('basic Error');
+  });
+
+  it('should execute getServerErrorMessage', () => {
+    const service: ErrorService = TestBed.get(ErrorService);
+    const error = new HttpErrorResponse({
+        error: 'server Error',
+        status: 500,
+        statusText: 'bad status',
+        url: 'http://wiki.stuff/something'
+    });
+    expect(service.getServerErrorMessage(error)).toEqual(
+        'Http failure response for http://wiki.stuff/something: 500 bad status'
+    );
+  });
+});

--- a/src/app/_services/error.service.ts
+++ b/src/app/_services/error.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorService {
+
+  getClientErrorMessage(error: Error): string {
+    return error.message ?
+           error.message :
+           error.toString();
+  }
+
+  getServerErrorMessage(error: HttpErrorResponse): string {
+    return navigator.onLine ?
+           error.message :
+           'No Internet Connection';
+  }
+}

--- a/src/app/_services/error.service.ts
+++ b/src/app/_services/error.service.ts
@@ -8,13 +8,13 @@ export class ErrorService {
 
   getClientErrorMessage(error: Error): string {
     return error.message ?
-           error.message :
-           error.toString();
+      error.message :
+      error.toString();
   }
 
   getServerErrorMessage(error: HttpErrorResponse): string {
     return navigator.onLine ?
-           error.message :
-           'No Internet Connection';
+      error.message :
+      'No Internet Connection';
   }
 }

--- a/src/app/_shared/global-error.handler.ts
+++ b/src/app/_shared/global-error.handler.ts
@@ -1,0 +1,29 @@
+import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { LoggingService } from '../_services/logging/logging.service';
+import { ErrorService } from '../_services/error.service';
+import { LogLevels } from '../_enums/log-levels.enum';
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+
+  constructor(private injector: Injector) { }
+
+  handleError(error: Error | HttpErrorResponse) {
+    const errorService = this.injector.get(ErrorService);
+    const logger = this.injector.get(LoggingService);
+
+    let message;
+    if (error instanceof HttpErrorResponse) {
+      // Server error
+      message = errorService.getServerErrorMessage(error);
+
+    } else {
+      // Client Error
+      message = errorService.getClientErrorMessage(error);
+    }
+
+    // Always log errors
+    logger.log(message, LogLevels.error);
+  }
+}

--- a/src/app/_shared/shared.module.ts
+++ b/src/app/_shared/shared.module.ts
@@ -1,8 +1,11 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule, ModuleWithProviders, ErrorHandler } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
+
+import { GlobalErrorHandler } from './global-error.handler';
+import {ServerErrorInterceptor } from '../_interceptors/server-error.interceptor';
 
 @NgModule({
   declarations: [],
@@ -17,7 +20,11 @@ import { FormsModule } from '@angular/forms';
     HttpClientModule,
     BrowserModule,
     FormsModule
-  ]
+  ],
+  providers: [
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
+    { provide: HTTP_INTERCEPTORS, useClass: ServerErrorInterceptor, multi: true }
+  ],
 })
 export class SharedModule {
   static forRoot(): ModuleWithProviders {


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-321

 ## Description:
Add global error handler that implements the logging service. This will be great for one stop shop to send all app errors to a server/db in the future.

 ## Testing:
`npm run test`

 ## Screenshots:
(if applicable)