### PR TITLE
Add monitors module + pages structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "homepage": "https://github.com/racker/Minerva#readme",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --public-host dev.i.rax.io --baseHref=/intelligence",
-    "start-mock": "ng serve -c mock --baseHref=/intelligence",
+    "start": "ng serve --public-host dev.i.rax.io --baseHref=/intelligence -o",
+    "start-mock": "ng serve -c mock --baseHref=/intelligence --public-host dev.i.rax.io -o",
     "build": "ng build --watch",
     "build-mock": "ng build --watch -c mock",
     "build-deploy": "ng build",

--- a/src/app/_features/monitors/monitors.module.ts
+++ b/src/app/_features/monitors/monitors.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { SharedModule } from '../../_shared/shared.module';
-import { MonitorslistComponent } from './components/list/monitorslist.component';
+//import { MonitorslistComponent } from './components/list/monitorslist.component';
 import { MonitorsPage } from './pages/monitors/monitors.page';
 
 const routes: Routes = [
@@ -20,7 +20,7 @@ const routes: Routes = [
   ],
   declarations: [
     MonitorsPage,
-    MonitorslistComponent
+    //MonitorslistComponent
   ],
   imports: [
     SharedModule,

--- a/src/app/_features/monitors/monitors.module.ts
+++ b/src/app/_features/monitors/monitors.module.ts
@@ -1,0 +1,30 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SharedModule } from '../../_shared/shared.module';
+import { MonitorslistComponent } from './components/list/monitorslist.component';
+import { MonitorsPage } from './pages/monitors/monitors.page';
+
+const routes: Routes = [
+  {
+      path: '',
+      component: MonitorsPage,
+      data: {
+        breadcrumb: ''
+      }
+  }
+];
+
+@NgModule({
+  schemas: [
+    CUSTOM_ELEMENTS_SCHEMA
+  ],
+  declarations: [
+    MonitorsPage,
+    MonitorslistComponent
+  ],
+  imports: [
+    SharedModule,
+    RouterModule.forChild(routes)
+  ]
+})
+export class MonitorsModule { }

--- a/src/app/_features/monitors/pages/monitors/monitors.page.html
+++ b/src/app/_features/monitors/pages/monitors/monitors.page.html
@@ -1,0 +1,3 @@
+<p>
+  monitors.page works!
+</p>

--- a/src/app/_features/monitors/pages/monitors/monitors.page.spec.ts
+++ b/src/app/_features/monitors/pages/monitors/monitors.page.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MonitorsPage } from './monitors.page';
+
+describe('MonitorsPage', () => {
+  let component: MonitorsPage;
+  let fixture: ComponentFixture<MonitorsPage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MonitorsPage ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MonitorsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/_features/monitors/pages/monitors/monitors.page.ts
+++ b/src/app/_features/monitors/pages/monitors/monitors.page.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-monitors.page',
+  templateUrl: './monitors.page.html',
+  styleUrls: ['./monitors.page.less']
+})
+export class MonitorsPage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+
+  }
+}

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -7,6 +7,11 @@ const routes: Routes = [
       breadcrumb: 'RESOURCES'
     }
   },
+  { path: 'monitors', loadChildren: './_features/monitors/monitors.module#MonitorsModule',
+    data: {
+      breadcrumb: 'RESOURCES'
+    }
+  },
   { path: '', redirectTo: '/resources', pathMatch: 'full'},
   { path: '**', redirectTo: '/resources'}
 ];

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -9,7 +9,7 @@ const routes: Routes = [
   },
   { path: 'monitors', loadChildren: './_features/monitors/monitors.module#MonitorsModule',
     data: {
-      breadcrumb: 'RESOURCES'
+      breadcrumb: 'MONITORS'
     }
   },
   { path: '', redirectTo: '/resources', pathMatch: 'full'},


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-341

 ## Description:
Introduces the Monitors module and accompanying pages

 ## Testing:
`npm run test` or navigate to `http://dev.i.rax.io:(4200 || 3000)/intelligence/monitors`

 ## Screenshots:
![monitorsScreenshot](https://user-images.githubusercontent.com/5041718/59381316-b7955d80-8d20-11e9-8ec2-746de452afea.png)