### PR TITLE
update API environment endpoints + adjusted collections Resources API 

### DIFF
--- a/localenv/package-lock.json
+++ b/localenv/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -158,6 +163,30 @@
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
           "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
           "dev": true
+        }
+      }
+    },
+    "axios-debug-log": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/axios-debug-log/-/axios-debug-log-0.6.2.tgz",
+      "integrity": "sha512-aavexsFWw+T09e9JkbsNe/zLjdG4r2vwhnKUtCNC/0wpogI/i+bQWJ0jJIuXof734dQ43uiOiFPgbRu8EVa64Q==",
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/localenv/package.json
+++ b/localenv/package.json
@@ -33,5 +33,8 @@
       ".",
       "../src"
     ]
+  },
+  "dependencies": {
+    "axios-debug-log": "^0.6.2"
   }
 }

--- a/localenv/routes/salus.js
+++ b/localenv/routes/salus.js
@@ -6,11 +6,7 @@ var devEnv = process.env.NODE_ENV === 'dev';
 const Settings = require('../config/index');
 var Identity = require('../services/identity/token');
 var mockPath = path.join(__dirname, '../../src/app/_mocks');
-
 const config = new Settings();
-const authToken = {
-    'x-auth-token': Identity.info().token.id
-};
 
 router.get('/resources', (req, res) => {
     let page = req.query.page;
@@ -26,7 +22,8 @@ router.get('/resources', (req, res) => {
                 size,
                 page
             },
-            authToken
+            headers: { 'x-auth-token':Identity.info().token.id }
+
         })
         .then((data) => {
             res.send(data.data);
@@ -45,7 +42,7 @@ router.get('/resources/:id', (req, res) => {
     }
     else {
         axios.get(`${config.monitoring.api_host}${config.monitoring.api_url}/${Identity.info().token.tenant.id}/resources/${id}`, {
-            authToken
+            'x-auth-token':  Identity.info().token.id
         })
         .then((data) => {
             res.send(data.data);

--- a/localenv/server.js
+++ b/localenv/server.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({'extended':'false'}));
 
 // this route is reserved for all api requests used in the app
-app.use('/intelligence/api', Api);
+app.use('/api', Api);
 
 // all unmatched requests to this path, with no file extension, redirect to index
 app.use('/intelligence', function ( req, res, next ) {

--- a/localenv/services/identity/token.js
+++ b/localenv/services/identity/token.js
@@ -4,7 +4,10 @@ const request = require('request');
 const Settings = require('../../config/index');
 
 const config = new Settings();
-var _authInfo = {};
+var _authInfo = {
+    token: '',
+    user: ''
+};
 var Authenticate = {};
 
 Authenticate.info = function() {

--- a/src/app/_features/resources/components/list/resourceslist.component.html
+++ b/src/app/_features/resources/components/list/resourceslist.component.html
@@ -42,7 +42,7 @@
           <hx-checkbox id="chk{{resource.id}}" (change)="selectResource(resource)"
             [checked]="resource.checked"></hx-checkbox>
       </td>
-      <td><a [routerLink]="['/resources', resource.id]">{{resource.resourceId}}</a></td>
+      <td><a [routerLink]="['/resources', resource.resourceId]">{{resource.resourceId}}</a></td>
       <td>--</td>
       <td>3</td>
       <td>8</td>

--- a/src/app/_features/resources/components/list/resourceslist.component.spec.ts
+++ b/src/app/_features/resources/components/list/resourceslist.component.spec.ts
@@ -66,7 +66,7 @@ describe('ResourcesListComponent', () => {
     });
 
     it('should assign current page', () => {
-      expect(component.page).toEqual(1);
+      expect(component.page).toEqual(0);
     });
 
     it('should create correct placeholder text', () => {
@@ -104,13 +104,13 @@ describe('ResourcesListComponent', () => {
   });
 
   it('should goto page', () => {
-    component.goToPage(3);
-    expect(component.page).toEqual(3);
+    component.goToPage(2);
+    expect(component.page).toEqual(2);
   });
 
   it('should goto next page', () => {
     component.nextPage();
-    expect(component.page).toEqual(2);
+    expect(component.page).toEqual(1);
   });
 
   it('should goto previous page', () => {

--- a/src/app/_features/resources/components/list/resourceslist.component.ts
+++ b/src/app/_features/resources/components/list/resourceslist.component.ts
@@ -15,7 +15,7 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
   searchPlaceholderText: string;
   resources: any = [];
   total: number;
-  page: number = 1;
+  page: number = 0;
   defaultAmount: number = environment.pagination.pageSize;
   totalPages: number;
   fetchResources: any;
@@ -31,8 +31,6 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
         ).subscribe(data => {
           this.resources = this.resourceService.resources.content;
           this.total = this.resourceService.resources.totalElements;
-          // reapply once API logic is confirmed
-          //this.page = this.resourceService.resources.default.number + 1;
           this.searchPlaceholderText = `Search ${this.total} Resources`;
         });
     }

--- a/src/app/_services/resources/resources.service.spec.ts
+++ b/src/app/_services/resources/resources.service.spec.ts
@@ -29,11 +29,11 @@ describe('ResourcesService', () => {
   describe('CRUD Operations', () => {
     it('should return collection', () => {
       const service: ResourcesService = TestBed.get(ResourcesService);
-      service.getResources(environment.pagination.resources.pageSize, 1).subscribe((data) => {
+      service.getResources(environment.pagination.resources.pageSize, 0).subscribe((data) => {
         let mocked = new resourcesMock().collection;
         let slicedArray = new resourcesMock().collection.content
          .slice(0 * environment.pagination.resources.pageSize, 1 * environment.pagination.resources.pageSize);
-        mocked.content = slicedArray
+        mocked.content = slicedArray;
         expect(data).toEqual(mocked);
       });
     });

--- a/src/app/_services/resources/resources.service.ts
+++ b/src/app/_services/resources/resources.service.ts
@@ -33,18 +33,17 @@ export class ResourcesService {
 
   getResources(size: number, page: number): Observable<any> {
     if (environment.mock) {
-      let pageNumber = --page;
       let mocks = Object.assign({}, this.mockedResources.collection);
-      let slicedData = [... mocks.content.slice(pageNumber * size, (pageNumber + 1) * size)];
+      let slicedData = [... mocks.content.slice(page * size, (page + 1) * size)];
       this.resources = mocks;
-      this.resources.content = slicedData
+      this.resources.content = slicedData;
       return of(this.resources);
     }
     else {
     return this.http.get(`${environment.api.salus}/resources?size=${size}&page=${page}`, httpOptions)
     .pipe(
       tap(data =>
-        { this.resources = data.content;
+        { this.resources = data;
           this.logService.log(this.resources, LogLevels.info);
         }));
     }

--- a/src/app/_shared/_components/pagination/pagination.component.html
+++ b/src/app/_shared/_components/pagination/pagination.component.html
@@ -1,16 +1,16 @@
   <div class="hxPagination hxBtnGroup" *ngIf="total > perPage">
-    <button class="hxBtn firstPage" (click)="onPage(1)" [disabled]="page === 1">
+    <button class="hxBtn firstPage" (click)="onPage(1)" [disabled]="page === 0">
       <hx-icon type="angle-start"></hx-icon>
     </button>
-    <button class="hxBtn prevPage" (click)="onPrev()" [disabled]="page === 1">
+    <button class="hxBtn prevPage" (click)="onPrev()" [disabled]="page === 0">
       <hx-icon type="angle-left"></hx-icon>
     </button>
-    <button class="hxBtn" *ngFor="let pageNum of getPages(); index as i" (click)="onPage(pageNum)"
-    [attr.aria-current]="(page-1) === i">{{ pageNum }}</button>
+    <button class="hxBtn" *ngFor="let pageNum of getPages(); index as i" (click)="onPage(pageNum - 1)"
+    [attr.aria-current]="(page) === i">{{ pageNum }}</button>
     <button class="hxBtn nextPage" (click)="onNext(true)" [disabled]="lastPage()">
       <hx-icon type="angle-right"></hx-icon>
     </button>
-    <button class="hxBtn lastPage" (click)="onPage(totalPages())" [disabled]="lastPage()">
+    <button class="hxBtn lastPage" (click)="onPage(totalPages() - 1)" [disabled]="lastPage()">
       <hx-icon type="angle-end"></hx-icon>
     </button>
   </div>

--- a/src/app/_shared/_components/pagination/pagination.component.spec.ts
+++ b/src/app/_shared/_components/pagination/pagination.component.spec.ts
@@ -19,7 +19,7 @@ describe('PaginationComponent', () => {
     fixture = TestBed.createComponent(PaginationComponent);
     component = fixture.componentInstance;
     // mock for a result set of 54 items returning 25 a page
-    component.page = 1;
+    component.page = 0;
     component.total = 54;
     component.perPage = 25;
     fixture.detectChanges();

--- a/src/app/_shared/_components/pagination/pagination.component.ts
+++ b/src/app/_shared/_components/pagination/pagination.component.ts
@@ -22,11 +22,11 @@ export class PaginationComponent {
   constructor() { }
 
   getMin(): number {
-    return ((this.perPage * this.page) - this.perPage) + 1;
+    return ((this.perPage * (this.page + 1)) - this.perPage) + 1;
   }
 
   getMax(): number {
-    let max = this.perPage * this.page;
+    let max = this.perPage * (this.page + 1);
     if (max > this.total) {
       max = this.total;
     }
@@ -50,7 +50,7 @@ export class PaginationComponent {
   }
 
   lastPage(): boolean {
-    return this.perPage * this.page > this.total;
+    return this.perPage * (this.page + 1) > this.total;
   }
 
   getPages(): number[] {

--- a/src/environments/environment.mock.ts
+++ b/src/environments/environment.mock.ts
@@ -1,13 +1,13 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-
+let absoluteHost = `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
 export const environment = {
   production: false,
   mock: true,
   api: {
-    salus: 'api/salus',
-    metrics: 'api/metrics'
+    salus: `${absoluteHost}/api/salus`,
+    metrics: `${absoluteHost}/api/metrics`
   },
   pagination: {
     pageSize: 25,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: true,
   mock: false,
   api: {
-    salus: 'api/salus',
+    salus: 'https://api/salus',
     metrics: 'api/metrics'
   },
   pagination: {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,13 +1,13 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-
+let absoluteHost = `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
 export const environment = {
   production: false,
   mock: false,
   api: {
-    salus: 'api/salus',
-    metrics: 'api/metrics'
+    salus: `${absoluteHost}/api/salus`,
+    metrics: `${absoluteHost}/api/metrics`
   },
   pagination: {
     pageSize: 25,


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-405

 ## Description:
Portal had requested that we make the API endpoints absolute instead of relative as this was messing up the requests (_./environments/environment.ts_).

Tested and connected Salus - Resource API for Prod environment and adjusted the pagination and count to reflect the API accurately.

This then made it necessary to update the pagination component & tests as I was not previously using a base zero for the paging.

 ## Testing:
`npm run test`

 ## Screenshots:
**Live data from Salus Prod!** 
![ProdMonitoring](https://user-images.githubusercontent.com/5041718/67797972-b6a36500-fa50-11e9-8691-1a33b3cc4b3a.png)