### PR TITLE
Update Resource + Field Validators

### DIFF
--- a/localenv/routes/salus.js
+++ b/localenv/routes/salus.js
@@ -52,8 +52,26 @@ router.get('/resources/:id', (req, res) => {
             res.sendStatus(500).json(err);
         });
     }
-
 });
+
+router.put('/resources/:id', (req, res) => {
+    if (devEnv) {
+        const data = require(`${mockPath}/resources/single.json`);
+        res.json(data);
+    }
+    else {
+        let id = req.params.id;
+        let updated = req.body;
+        axios.put(`${config.monitoring.api_host}${config.monitoring.api_url}/${Identity.info().token.tenant.id}/resources/${id}`,
+        updated, { headers: { 'x-auth-token':Identity.info().token.id }})
+        .then((data) => {
+            res.send(data.data);
+        })
+        .catch((err) => {
+            res.sendStatus(500).json(err);
+        });
+    }
+})
 
 
 module.exports = router;

--- a/src/app/_features/resources/pages/details/resource-details.page.html
+++ b/src/app/_features/resources/pages/details/resource-details.page.html
@@ -15,7 +15,7 @@
     <hx-menu id="basicMenuId">
       <section>
         <header>Manage</header>
-        <hx-menuitem>Rename Entity</hx-menuitem>
+        <hx-menuitem>Rename Resource</hx-menuitem>
         <hx-menuitem>Add IP</hx-menuitem>
         <hx-menuitem>Delete Entity</hx-menuitem>
       </section>
@@ -43,7 +43,8 @@
 
 <div class="hxRow hxSpan-9">
   <div class="hxCol hxSpan-6">
-    <h4>Metadata</h4>
+    <h4 class="inline-icon">Metadata</h4><hx-disclosure aria-controls="metaPopover" #metapop id="metapop" class="editclick">
+      <hx-icon type="pencil"></hx-icon></hx-disclosure>
     <div *ngIf="resource.metadata">
      <div class="hxRow" *ngFor="let address of Object.keys(resource.metadata)">
       <div class="hxCol">
@@ -53,8 +54,25 @@
         {{resource.metadata[address]}}
       </div>
     </div>
+  <hx-popover id="metaPopover" position="bottom-right">
+    <header>
+      Metadata fields
+    </header>
+    <hx-div>
+      <app-add-fields [initialData]="resource.metadata" [validateForm]="metaSubmit.asObservable()"
+      (formValuesChanged)="metaValueUpdated($event)" (formValid)="metaFormSubmit.next($event)">
+      </app-add-fields>
+    </hx-div>
+    <footer>
+      <button class="hxBtn hxPrimary" [disabled]="metaLoading" (click)="metaLoading = true; metaSubmit.next()">
+        <hx-busy class="popover-busy" *ngIf="metaLoading"></hx-busy>
+        Submit</button>
+      <button class="hxBtn" (click)="metaPopPencil.nativeElement.click()" aria-controls="metaPopover">Cancel</button>
+    </footer>
+  </hx-popover>
     </div>
   </div>
+
   <div class="hxCol hxSpan-6">
     <h4>Created Date</h4>
     {{resource.createdTimestamp |  date:'MM/dd/yyyy'}}
@@ -74,7 +92,8 @@
 
 <div class="hxRow hxSpan-9 last-item">
   <div class="hxCol hxSpan-6">
-    <h4>Labels</h4>
+    <h4 class="inline-icon">Labels</h4><hx-disclosure aria-controls="labelPopover" #labelpop id="labelpop" class="editclick">
+        <hx-icon type="pencil"></hx-icon></hx-disclosure>
     <div *ngIf="resource.labels">
     <div class="hxRow" *ngFor="let label of Object.keys(resource.labels)">
         <div class="hxCol hxSpan-6">
@@ -84,6 +103,23 @@
           {{resource.labels[label]}}
         </div>
       </div>
+  <hx-popover id="labelPopover" position="bottom-right">
+      <header>
+        Labels
+      </header>
+      <hx-div>
+        <app-add-fields [initialData]="resource.labels" [validateForm]="labelsSubmit.asObservable()"
+        [labelContraints]="true" (formValuesChanged)="labelsUpdated($event)" (formValid)="labelFormSubmit.next($event)">
+        </app-add-fields>
+      </hx-div>
+      <footer>
+        <button class="hxBtn hxPrimary" [disabled]="labelsLoading" (click)="labelsLoading = true; labelsSubmit.next()">
+          <hx-busy class="popover-busy" *ngIf="labelsLoading"></hx-busy>
+          Submit</button>
+        <button class="hxBtn" [disabled]="labelsLoading" (click)="labelPopPencil.nativeElement.click()" aria-controls="metaPopover">Cancel</button>
+      </footer>
+    </hx-popover>
+
     </div>
   </div>
 </div>

--- a/src/app/_features/resources/pages/details/resource-details.page.scss
+++ b/src/app/_features/resources/pages/details/resource-details.page.scss
@@ -3,9 +3,18 @@
 }
 
 .hxRow.last-item {
-    margin-bottom:40px;
+    margin-bottom: 40px;
 }
 
 .cog-menu-div {
-    padding-top:10px
+    padding-top: 10px;
+}
+
+h4.inline-icon {
+    display: inline-block;
+    padding-right: 5px;
+}
+
+hx-busy.popover-busy {
+    margin-right: 5px;
 }

--- a/src/app/_features/resources/pages/details/resource-details.page.spec.ts
+++ b/src/app/_features/resources/pages/details/resource-details.page.spec.ts
@@ -1,14 +1,15 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, getTestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
 import { ResourcesPage } from '../resources/resources.page';
 import { ResourceDetailsPage } from './resource-details.page';
 import { ResourcesListComponent } from '../../components/list/resourceslist.component';
 import { resourcesMock } from '../../../../_mocks/resources/resources.service.mock';
 import { SharedModule } from '../../../../_shared/shared.module';
+import { ResourcesService } from 'src/app/_services/resources/resources.service';
+import { of, Observable } from 'rxjs';
 
 const routes = [
   {
@@ -61,8 +62,10 @@ const formattedKeyPair = {
 }
 
 describe('ResourceDetailsPage', () => {
+  let injector: TestBed;
   let component: ResourceDetailsPage;
   let fixture: ComponentFixture<ResourceDetailsPage>;
+  let resourceService: ResourcesService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -81,7 +84,8 @@ describe('ResourceDetailsPage', () => {
               routeConfig : routes[0]
             }
           }
-        }
+        },
+        ResourcesService
       ],
       imports: [
         SharedModule,
@@ -93,8 +97,10 @@ describe('ResourceDetailsPage', () => {
   }));
 
   beforeEach(() => {
+    injector = getTestBed();
     fixture = TestBed.createComponent(ResourceDetailsPage);
     component = fixture.componentInstance;
+    resourceService = injector.get(ResourcesService);
     fixture.detectChanges();
   });
 
@@ -121,9 +127,29 @@ describe('ResourceDetailsPage', () => {
     expect(component.updatedMetaFields).toEqual(formattedKeyPair);
   });
 
+  it('should finalize update of meta values finalizeMeta()', (done) => {
+
+    let spy = spyOn(resourceService, 'updateResource')
+    .and.returnValue(of(new resourcesMock().single));;
+    resourceService.resource = new resourcesMock().single;
+    component.metaValueUpdated(keyPair);
+    component.finalizeMeta();
+    expect(spy).toHaveBeenCalled();
+    done();
+  });
+
   it('should update & format label values', () => {
     component.labelsUpdated(keyPair);
     expect(component.updatedLabelFields).toEqual(formattedKeyPair);
+  });
+
+  it('should finalize update of label values finalizeLabels()', (done) => {
+    let spy = spyOn(resourceService, 'updateResource').and.returnValue(of(new resourcesMock().single));
+    resourceService.resource = new resourcesMock().single;
+    component.labelsUpdated(keyPair);
+    component.finalizeLabels();
+    expect(spy).toHaveBeenCalled();
+    done();
   });
 
   it('should set to a single resource', () => {
@@ -132,5 +158,5 @@ describe('ResourceDetailsPage', () => {
       expect(resource).toEqual(mocked);
     });
 
-  })
+  });
 });

--- a/src/app/_features/resources/pages/details/resource-details.page.spec.ts
+++ b/src/app/_features/resources/pages/details/resource-details.page.spec.ts
@@ -11,7 +11,8 @@ import { resourcesMock } from '../../../../_mocks/resources/resources.service.mo
 import { SharedModule } from '../../../../_shared/shared.module';
 
 const routes = [
-  { path: 'resources',
+  {
+    path: 'resources',
     data: {
       breadcrumb: 'RESOURCES'
     },
@@ -21,16 +22,43 @@ const routes = [
       data: {
         breadcrumb: ''
       }
-  },
-  {
+    },
+    {
       path: ':id',
       component: ResourceDetailsPage,
       data: {
         breadcrumb: 'DETAILS'
       }
-  }]
+    }]
   }
 ];
+
+const keyPair = {
+  keysandvalues: [
+  {
+    key: 'newkey',
+    value: 'newpair'
+  },
+  {
+    key: 'likelykey',
+    value: 'likelypair'
+  },
+  {
+    key: 'somekey',
+    value: 'somepair'
+  },
+  {
+    key: 'fourthkey',
+    value: 'fourthpair'
+  }
+]};
+
+const formattedKeyPair = {
+  newkey: 'newpair',
+  likelykey: 'likelypair',
+  somekey: 'somepair',
+  fourthkey: 'fourthpair'
+}
 
 describe('ResourceDetailsPage', () => {
   let component: ResourceDetailsPage;
@@ -74,19 +102,35 @@ describe('ResourceDetailsPage', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should setup defaults', () => {
+    expect(component.resource$).toBeDefined();
+    expect(component.Object).toEqual(Object);
+    expect(component.metaLoading).toEqual(false);
+    expect(component.labelsLoading).toEqual(false);
+    expect(component.metaPopPencil).toBeDefined();
+    expect(component.labelPopPencil).toBeDefined()
+    expect(component.subManager).toBeDefined();
+  });
+
   it('should have a route param', () => {
     expect(component.id).toEqual("uniqueId");
   });
 
-  it('should declare Object', () => {
-    expect(component.Object).toEqual(Object);
-  })
+  it('should update and format meta values', () => {
+    component.metaValueUpdated(keyPair);
+    expect(component.updatedMetaFields).toEqual(formattedKeyPair);
+  });
+
+  it('should update & format label values', () => {
+    component.labelsUpdated(keyPair);
+    expect(component.updatedLabelFields).toEqual(formattedKeyPair);
+  });
 
   it('should set to a single resource', () => {
     let mocked = new resourcesMock().single;
     component.resource$.subscribe((resource) => {
       expect(resource).toEqual(mocked);
-    })
+    });
 
   })
 });

--- a/src/app/_features/resources/pages/details/resource-details.page.ts
+++ b/src/app/_features/resources/pages/details/resource-details.page.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ResourcesService } from '../../../../_services/resources/resources.service';
-import { Observable } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { Resource } from 'src/app/_models/resources';
+import { tap } from 'rxjs/operators';
 
 declare const window: any;
 @Component({
@@ -11,22 +12,114 @@ declare const window: any;
   styleUrls: ['./resource-details.page.scss']
 })
 export class ResourceDetailsPage implements OnInit {
+
+  @ViewChild('metapop') metaPopPencil:ElementRef;
+  @ViewChild('labelpop') labelPopPencil:ElementRef;
   id: string;
-  meta: {};
-  //TODO: create Interface for a single Resource - will be mapped to
-  // service & response
+
   resource$: Observable<Resource>;
+  private metaSubmit: Subject<void> = new Subject<void>();
+  private labelsSubmit: Subject<void> = new Subject<void>();
+  private metaFormSubmit: Subject<boolean> = new Subject<boolean>();
+  private labelFormSubmit: Subject<boolean> = new Subject<boolean>();
+  subManager = new Subscription();
+
   Object = window.Object;
+  metaLoading:boolean = false;
+  labelsLoading:boolean = false;
+  updatedMetaFields: {[key: string] : any};
+  updatedLabelFields: any;
 
   constructor(private route: ActivatedRoute, private resourceService: ResourcesService) { }
 
-  // TODO: attempt to move this logic to a route resolve as opposed
-  // to making the request within the component
+  // TODO(optional): attempt to move this logic to a route resolve as opposed
+  // to connecting the subscription to the request within the component
   ngOnInit() {
     this.route.params.subscribe(params => {
       this.id = params['id'];
       this.resource$ = this.resourceService.getResource(this.id);
     });
+
+    let metaFormSubscrip = this.metaFormSubmit.subscribe((valid) => {
+      if (!valid) {
+        this.metaLoading = false;
+      }
+      else {
+        this.finalizeMeta();
+      }
+    });
+
+    let labelFormSubscrip = this.labelFormSubmit.subscribe((valid) => {
+      if (!valid) {
+        this.labelsLoading = false;
+      }
+      else {
+        this.finalizeLabels();
+      }
+    });
+
+    this.subManager.add(metaFormSubscrip);
+    this.subManager.add(labelFormSubscrip);
   }
 
+  /**
+   * @description Whenever updates are made to the form we retrieve values here
+   * @param metaValues {[key: string] : any}
+   */
+  metaValueUpdated(metaValues: {[key: string] : any}):void {
+    this.updatedMetaFields = this.transformKeyPairs(metaValues.keysandvalues);
+  }
+
+  /**
+   * @description When fields are valid we then make the request to the server
+   * and tie it the subscription of the resource$ being used in the template
+   */
+  finalizeMeta() {
+    this.updatedMetaFields = { 'metadata': this.updatedMetaFields};
+    this.resource$ = this.resourceService.updateResource(this.resourceService.resource.resourceId,
+      this.updatedMetaFields).pipe(
+        tap(x => {
+          this.metaLoading = false
+        })
+      )
+  }
+  /**
+   * @description Whenever updates are made to the form we retrieve values here
+   * @param labelValues {[key: string] : any}
+   */
+  labelsUpdated(labelValues: {[key: string] : any}): void {
+    this.updatedLabelFields = this.transformKeyPairs(labelValues.keysandvalues);
+  }
+
+  /**
+   * @description When fields are valid we then make the request to the server
+   */
+  finalizeLabels() {
+    this.updatedLabelFields = { 'labels': this.updatedLabelFields};
+    this.resource$ = this.resourceService.updateResource(this.resourceService.resource.resourceId,
+      this.updatedLabelFields).pipe(
+        tap(x => {
+          this.labelsLoading = false
+        })
+      );
+  }
+
+  /**
+   * @description Turns the array of key pairs into an object
+   * @param keyPairs [{[key: string] : any}]
+   * @returns {}
+   */
+  private transformKeyPairs(keyPairs: [{[key: string] : any}]): {} {
+    let paired = {};
+    keyPairs.forEach(element => {
+      if (element.key && element.value) {
+        paired[element.key] = element.value;
+      }
+    });
+    return paired;
+  }
+
+  ngOnDestroy() {
+    this.subManager.unsubscribe();
+  }
 }

--- a/src/app/_models/resources.ts
+++ b/src/app/_models/resources.ts
@@ -4,14 +4,15 @@ interface Labels {
     agent_discovered_hostname: string;
     agent_discovered_os: string;
 
-    [x: string]: any
+    [key: string]: any
 }
+
 export interface Resource {
     tenantId: string;
     resourceId: string;
     labels: Labels;
     metadata: {
-        [x: string]: any;
+        [key: string]: any;
     }
     presenceMonitoringEnabled: boolean;
     associatedWithEnvoy: boolean;

--- a/src/app/_services/resources/resources.service.spec.ts
+++ b/src/app/_services/resources/resources.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ResourcesService } from './resources.service';
 import { environment } from '../../../environments/environment';
 import { resourcesMock } from '../../_mocks/resources/resources.service.mock';
-import { Resources } from 'src/app/_models/resources';
+import { Resources, Resource } from 'src/app/_models/resources';
 
 describe('ResourcesService', () => {
   beforeEach(() => {
@@ -49,6 +49,14 @@ describe('ResourcesService', () => {
     it('should return single resource', () => {
       const service: ResourcesService = TestBed.get(ResourcesService);
       service.getResource("linuxResource").subscribe((data) => {
+        expect(data).toEqual(new resourcesMock().single);
+      });
+    });
+
+    it('should update a single resource metadata or labels', () => {
+      const service: ResourcesService = TestBed.get(ResourcesService);
+      let updated = {labels: {'newkey': 'newVal', 'somekey':'someVal'}};
+      service.updateResource("linuxResource", updated).subscribe((data:Resource) => {
         expect(data).toEqual(new resourcesMock().single);
       });
     });

--- a/src/app/_services/resources/resources.service.ts
+++ b/src/app/_services/resources/resources.service.ts
@@ -72,6 +72,7 @@ export class ResourcesService {
    */
   getResource(id: string): Observable<Resource> {
     if (environment.mock) {
+      this._resource = this.mockedResources.single;
       return of<Resource>(this.mockedResources.single);
     }
     else {
@@ -98,6 +99,7 @@ export class ResourcesService {
    */
   updateResource(id:string, updatedData: {[key: string]: any}): Observable<Resource> {
     if (environment.mock) {
+      this._resource = this.mockedResources.single
       return of<Resource>(this.mockedResources.single);
     }
     else {

--- a/src/app/_services/resources/resources.service.ts
+++ b/src/app/_services/resources/resources.service.ts
@@ -20,6 +20,7 @@ const httpOptions = {
 export class ResourcesService {
 
   private _resources: Resources;
+  private _resource: Resource;
   private mockedResources = new resourcesMock();
 
   constructor(private http:HttpClient, private logService: LoggingService) { }
@@ -32,6 +33,20 @@ export class ResourcesService {
     this._resources = value;
   }
 
+  get resource(): Resource {
+    return this._resource;
+  }
+
+  set resource(value: Resource) {
+    this._resource = value;
+  }
+
+  /**
+   * Gets a list of Resources
+   * @param size
+   * @param page
+   * @returns Observable<Resources>
+   */
   getResources(size: number, page: number): Observable<Resources> {
     if (environment.mock) {
       let mocks = Object.assign({}, this.mockedResources.collection);
@@ -44,14 +59,17 @@ export class ResourcesService {
     return this.http.get<Resources>(`${environment.api.salus}/resources?size=${size}&page=${page}`, httpOptions)
     .pipe(
       tap(data =>
-        { this.resources = data;
+        { this._resources = data;
           this.logService.log(this.resources, LogLevels.info);
         }));
     }
   }
 
-  // TODO: establish interface for return data of individual
-  // resources
+  /**
+   * Gets a single Resource
+   * @param id
+   * @returns Observable<Resource>
+   */
   getResource(id: string): Observable<Resource> {
     if (environment.mock) {
       return of<Resource>(this.mockedResources.single);
@@ -59,9 +77,11 @@ export class ResourcesService {
     else {
       return this.http.get<Resource>(`${environment.api.salus}/resources/${id}`)
       .pipe(
-        tap(data => {
-          this.logService.log(`Resource: ${data}`, LogLevels.info);
-        })
+        tap(data =>
+          {
+            this._resource = data;
+            this.logService.log(`Resource: ${data}`, LogLevels.info);
+          })
       );
     }
   }
@@ -70,8 +90,26 @@ export class ResourcesService {
     return of();
   }
 
-  updateResource(id:number): Observable<any> {
-    return of();
+  /**
+   * Updates a resource
+   * @param id string
+   * @param updatedData {[key: string]: any}
+   * @returns Observable<Resource>
+   */
+  updateResource(id:string, updatedData: {[key: string]: any}): Observable<Resource> {
+    if (environment.mock) {
+      return of<Resource>(this.mockedResources.single);
+    }
+    else {
+      return this.http.put<Resource>(`${environment.api.salus}/resources/${id}`,
+      updatedData)
+      .pipe(
+        tap(data => {
+          this._resource = data,
+          this.logService.log(`Resource: ${data}`, LogLevels.info);
+        })
+      )
+    }
   }
 
 }

--- a/src/app/_shared/_components/add-fields/add-fields.component.html
+++ b/src/app/_shared/_components/add-fields/add-fields.component.html
@@ -1,0 +1,29 @@
+<!-- Accepts an Object to be used as key pair value matching for adding edited, deleted -->
+<form [formGroup]="keyValueForm">
+<div class="hxRow hxSpan-10 nowrap" formArrayName="keysandvalues"
+*ngFor="let field of keyValueForm.get('keysandvalues').controls; let i = index;">
+<ng-container [formGroupName]="i">
+<div class="hxCol hxSpan-6">
+<hx-text-control [attr.hx-dirty]="getGroupControl(i, 'key').dirty" [attr.hx-touched]="getGroupControl(i, 'key').touched">
+    <input id="txtKey" placeholder="key" [required]="(keyValueForm.controls.keysandvalues.controls[i].errors?.keyRequired &&
+    getGroupControl(i, 'key').touched)" [attr.agent_discovered]="getGroupControl(i, 'key').hasError('disallow') && getGroupControl(i, 'key').touched"
+    formControlName="key" type="text" />
+</hx-text-control>
+<span *ngIf="getGroupControl(i, 'key').hasError('disallow') && getGroupControl(i, 'key').touched" class="required">'agent_' is a reserved phrase</span>
+</div>
+<div class="hxCol hxSpan-6">
+    <hx-text-control [attr.hx-dirty]="getGroupControl(i, 'value').dirty" [attr.hx-touched]="getGroupControl(i, 'value').touched">
+        <input id="txtValue" placeholder="value" [required]="keyValueForm.controls.keysandvalues.controls[i].errors?.valRequired &&
+        getGroupControl(i, 'value').touched" formControlName="value" type="text" />
+    </hx-text-control>
+</div>
+<button class="hxBtn space-right inline-button" (click)="removeRow(i)">
+    <hx-icon type="minus"></hx-icon>
+</button>
+<button class="hxBtn inline-button" *ngIf="(i+1) === totalItems()" (click)="addRow()">
+    <hx-icon type="plus"></hx-icon>
+</button>
+<br/>
+</ng-container>
+</div>
+</form>

--- a/src/app/_shared/_components/add-fields/add-fields.component.scss
+++ b/src/app/_shared/_components/add-fields/add-fields.component.scss
@@ -1,0 +1,19 @@
+.nowrap {
+    flex-wrap: nowrap !important;
+}
+
+.space-right {
+    margin-right: 5px;
+}
+
+.inline-button {
+    height: 32px
+}
+
+span.required {
+    color: #d32f2f;
+}
+
+hx-text-control[hx-dirty]>input[agent_discovered=true] {
+    border: 2px solid #d32f2f;
+}

--- a/src/app/_shared/_components/add-fields/add-fields.component.spec.ts
+++ b/src/app/_shared/_components/add-fields/add-fields.component.spec.ts
@@ -1,0 +1,116 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { AddFieldsComponent } from './add-fields.component';
+import { Subject } from 'rxjs';
+
+describe('AddFieldsComponent', () => {
+  let component: AddFieldsComponent;
+  let fixture: ComponentFixture<AddFieldsComponent>;
+  let submitSubject: Subject<void> = new Subject<void>()
+
+  const onChange = () => {
+    component.ngOnChanges({
+      initialData: new SimpleChange(null, component.initialData, true)
+    });
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [ ReactiveFormsModule ],
+      declarations: [ AddFieldsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddFieldsComponent);
+    component = fixture.componentInstance;
+    component.initialData = { ping_ip: '127.0.0.1', mount: '/'};
+    component.validateForm = submitSubject.asObservable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('setup defaults', () => {
+    expect(component.formValuesChanged).toBeDefined();
+    expect(component.formValid).toBeDefined();
+    expect(component.keyValueForm).toBeDefined();
+    expect(component.subManager).toBeDefined();
+  });
+
+  it('should return length of initial form array', () => {
+    expect(component.metaPairs.length).toEqual(1);
+  });
+
+  it('should emit formvaluesChanged', () => {
+    spyOn(component.formValuesChanged, 'emit');
+    onChange();
+    component.ngOnInit();
+    component.getGroupControl(1, 'key').patchValue('forever');
+    expect(component.formValuesChanged.emit).toHaveBeenCalled();
+  });
+
+  it('should emit form submitted and valid', () => {
+    spyOn(component.formValid, 'emit');
+    onChange();
+    component.ngOnInit();
+    submitSubject.next();
+    expect(component.formValid.emit).toHaveBeenCalledWith(true);
+  });
+
+  it('should emit form submitted and invalid', () => {
+    spyOn(component.formValid, 'emit');
+    onChange();
+    component.ngOnInit();
+    component.getGroupControl(1, 'key').patchValue('');
+    submitSubject.next();
+    expect(component.formValid.emit).toHaveBeenCalledWith(false);
+
+  });
+
+  it('should add a row to form', () => {
+    component.addRow();
+    expect(component.metaPairs.length).toEqual(2);
+  });
+
+  it('should remove a row from form', () => {
+    component.addRow();
+    component.removeRow(0);
+    expect(component.metaPairs.length).toEqual(1);
+  });
+
+  it('should update form on changes', () => {
+    onChange();
+    component.ngOnInit();
+    expect(component.metaPairs.length).toEqual(3);
+  });
+
+  it('should create a row for form', () => {
+    component.metaPairs.push(component.createItem());
+    expect(component.metaPairs.length).toEqual(2);
+  });
+
+  it('should return control from index and fieldname', () => {
+    onChange();
+    component.ngOnInit();
+    expect(component.getGroupControl(1, 'key').value).toEqual('mount');
+  });
+
+  it('should return total items', () => {
+    onChange();
+    component.ngOnInit();
+    expect(component.totalItems()).toEqual(3);
+  });
+
+  it('should unsubscribe once component is destroyed', () => {
+    spyOn(component.subManager, 'unsubscribe');
+    component.ngOnDestroy();
+    expect(component.subManager.unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/app/_shared/_components/add-fields/add-fields.component.spec.ts
+++ b/src/app/_shared/_components/add-fields/add-fields.component.spec.ts
@@ -30,6 +30,7 @@ describe('AddFieldsComponent', () => {
     component = fixture.componentInstance;
     component.initialData = { ping_ip: '127.0.0.1', mount: '/'};
     component.validateForm = submitSubject.asObservable();
+    onChange();
     fixture.detectChanges();
   });
 
@@ -45,12 +46,12 @@ describe('AddFieldsComponent', () => {
   });
 
   it('should return length of initial form array', () => {
-    expect(component.metaPairs.length).toEqual(1);
+    component.ngOnInit();
+    expect(component.metaPairs.length).toEqual(3);
   });
 
   it('should emit formvaluesChanged', () => {
     spyOn(component.formValuesChanged, 'emit');
-    onChange();
     component.ngOnInit();
     component.getGroupControl(1, 'key').patchValue('forever');
     expect(component.formValuesChanged.emit).toHaveBeenCalled();
@@ -58,7 +59,6 @@ describe('AddFieldsComponent', () => {
 
   it('should emit form submitted and valid', () => {
     spyOn(component.formValid, 'emit');
-    onChange();
     component.ngOnInit();
     submitSubject.next();
     expect(component.formValid.emit).toHaveBeenCalledWith(true);
@@ -66,7 +66,6 @@ describe('AddFieldsComponent', () => {
 
   it('should emit form submitted and invalid', () => {
     spyOn(component.formValid, 'emit');
-    onChange();
     component.ngOnInit();
     component.getGroupControl(1, 'key').patchValue('');
     submitSubject.next();
@@ -76,34 +75,30 @@ describe('AddFieldsComponent', () => {
 
   it('should add a row to form', () => {
     component.addRow();
-    expect(component.metaPairs.length).toEqual(2);
+    expect(component.metaPairs.length).toEqual(4);
   });
 
   it('should remove a row from form', () => {
-    component.addRow();
     component.removeRow(0);
-    expect(component.metaPairs.length).toEqual(1);
+    expect(component.metaPairs.length).toEqual(2);
   });
 
   it('should update form on changes', () => {
-    onChange();
     component.ngOnInit();
     expect(component.metaPairs.length).toEqual(3);
   });
 
   it('should create a row for form', () => {
     component.metaPairs.push(component.createItem());
-    expect(component.metaPairs.length).toEqual(2);
+    expect(component.metaPairs.length).toEqual(4);
   });
 
   it('should return control from index and fieldname', () => {
-    onChange();
     component.ngOnInit();
     expect(component.getGroupControl(1, 'key').value).toEqual('mount');
   });
 
   it('should return total items', () => {
-    onChange();
     component.ngOnInit();
     expect(component.totalItems()).toEqual(3);
   });

--- a/src/app/_shared/_components/add-fields/add-fields.component.ts
+++ b/src/app/_shared/_components/add-fields/add-fields.component.ts
@@ -1,0 +1,157 @@
+import { Component, OnInit, Output, EventEmitter, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, FormControl, FormArray, AbstractControl } from '@angular/forms';
+import { keyPairValidator } from '../../validators/keyvalue.validator';
+import { disallowValidator } from '../../validators/disallow.validator';
+import { Subscription, Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+@Component({
+  selector: 'app-add-fields',
+  templateUrl: './add-fields.component.html',
+  styleUrls: ['./add-fields.component.scss']
+})
+export class AddFieldsComponent implements OnInit, OnChanges {
+  constructor(private fb: FormBuilder) { }
+  @Input()
+  initialData: { [key: string]: any };
+  @Input()
+  validateForm: Observable<void>;
+
+  // this functionality will disallow editing on any field containing
+  // the string passed along
+  @Input()
+  labelContraints: boolean;
+
+  // Output emitters will update the components as to changes in the form
+  // and whether they are valid
+  @Output()
+  public formValuesChanged = new EventEmitter<{ [key: string]: any }>();
+
+  @Output()
+  public formValid = new EventEmitter<boolean>();
+
+  // manage subscriptions
+  subManager = new Subscription();
+
+  public keyValueForm: FormGroup;
+  private addArray = [];
+
+  ngOnInit() {
+    // Begin by pushing all intialData key pairs to the form and
+    // pushing one empty set of inputs with appropriate validators
+    const sets = [];
+    sets.push(
+      ...this.addArray,
+      this.fb.group({
+      key: new FormControl('', ...(this.labelContraints && [disallowValidator])),
+      value: new FormControl('')
+    }, { validator: keyPairValidator }));
+
+    // finalize the form and push the fields to the FormArray
+    this.keyValueForm = this.fb.group({
+      keysandvalues: this.fb.array(sets)
+    });
+
+    // When changes are being made emit them via (formValuesChanged) of the component
+    let keyValueFormSub = this.keyValueForm.valueChanges.subscribe((meta) => {
+      this.formValuesChanged.emit(meta);
+    });
+
+    // When the parent component wants to know if the form is valid this will
+    // check and emit the results via (formValid)
+    let formValidSub = this.validateForm.subscribe(() => {
+        let valid = this.keyValueForm.valid;
+        this.markFormGroupTouched();
+        this.formValid.emit(valid);
+    });
+
+    // add all subsciptions to one manager
+    this.subManager.add(keyValueFormSub);
+    this.subManager.add(formValidSub);
+  }
+
+  /**
+   * @description used here to get the formarray and add inputs to it
+   * @returns FormArray
+   */
+  get metaPairs(): FormArray {
+    return this.keyValueForm.get('keysandvalues') as FormArray;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // gets the initial data and watches for changes
+    if (changes['initialData']) {
+      let sets = changes['initialData'].currentValue;
+      Object.keys(sets).map(key => {
+        let value = sets[key];
+        let disabled = key.startsWith(environment.resources.disallowLabelEdit);
+        this.addArray.push(this.fb.group({
+          key: new FormControl({value: key, disabled},
+            (this.labelContraints && [disallowValidator])),
+          value: new FormControl({value, disabled})
+        }, { validator: keyPairValidator }));
+      });
+    }
+  }
+
+  /**
+   * @description Add a new Row
+   */
+  addRow(): void {
+    this.metaPairs.push(this.createItem());
+  }
+
+  /**
+   * @description Removes the row
+   * @param index number
+   */
+  removeRow(index:number): void {
+    this.metaPairs.removeAt(index);
+  }
+
+  /**
+   * @description Creates a new pair of fields for the form
+   */
+  createItem(): FormGroup {
+    return this.fb.group({
+      key: new FormControl('', ...(this.labelContraints && [disallowValidator])),
+      value: []
+    }, { validator: keyPairValidator });
+  }
+
+  /**
+   * Returns the total of pairs
+   * @returns number
+   */
+  totalItems(): number {
+    return this.metaPairs.length;
+  }
+
+  /**
+   * @description Marks all form fields as touched to show validation upon submission
+   * @param formGroup FormGroup
+   */
+  private markFormGroupTouched() {
+    (<FormArray>this.keyValueForm.get('keysandvalues')).controls.forEach((group: FormGroup) => {
+      (<any>Object).values(group.controls).forEach((control: FormControl) => {
+          control.markAsDirty();
+          control.markAsTouched();
+      })
+    });
+  }
+
+  /**
+   * @description Returns the specific control referenced
+   * @param index number
+   * @param fieldName string
+   * @returns AbstractControl
+   */
+  getGroupControl(index:number, fieldName:string): AbstractControl {
+    return (<FormArray>this.keyValueForm.get('keysandvalues')).at(index).get(fieldName);
+  }
+
+  ngOnDestroy() {
+    this.subManager.unsubscribe();
+  }
+
+}

--- a/src/app/_shared/shared.module.ts
+++ b/src/app/_shared/shared.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, ModuleWithProviders, ErrorHandler, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule  } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { GlobalErrorHandler } from './global-error.handler';
@@ -10,6 +10,7 @@ import { BreadcrumbComponent } from './_components/breadcrumb/breadcrumb.compone
 import { PaginationComponent } from './_components/pagination/pagination.component';
 import { MeasurementNamePipe } from './pipes/measurement-name.pipe';
 import { DeviceNamePipe } from './pipes/device-name.pipe';
+import { AddFieldsComponent } from './_components/add-fields/add-fields.component';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
@@ -17,20 +18,24 @@ import { DeviceNamePipe } from './pipes/device-name.pipe';
     BreadcrumbComponent,
     PaginationComponent,
     MeasurementNamePipe,
-    DeviceNamePipe
+    DeviceNamePipe,
+    AddFieldsComponent
   ],
   imports: [
     CommonModule,
     HttpClientModule,
     FormsModule,
+    ReactiveFormsModule,
     RouterModule
   ],
   exports: [
     CommonModule,
     HttpClientModule,
     FormsModule,
+    ReactiveFormsModule,
     BreadcrumbComponent,
     PaginationComponent,
+    AddFieldsComponent,
     MeasurementNamePipe,
     DeviceNamePipe
   ],

--- a/src/app/_shared/validators/disallow.validator.spec.ts
+++ b/src/app/_shared/validators/disallow.validator.spec.ts
@@ -1,0 +1,25 @@
+import { async } from '@angular/core/testing';
+import { disallowValidator } from './disallow.validator'
+
+describe('disallowValidator', () => {
+    let testKeyString;
+    beforeEach(async(() => {
+        testKeyString = {
+            value: ''
+        }
+    }));
+
+    it('should create validator', () => {
+        expect(disallowValidator).toBeTruthy();
+    });
+
+    it('should validate against incorrect key entry', () => {
+        testKeyString.value = 'newKey';
+        expect(disallowValidator(testKeyString)).toEqual(null);
+    });
+
+    it('should invalidate missing key', () => {
+        testKeyString.value = 'agent_discovered';
+        expect(disallowValidator(testKeyString)).toEqual({ disallow: true });
+    });
+});

--- a/src/app/_shared/validators/disallow.validator.ts
+++ b/src/app/_shared/validators/disallow.validator.ts
@@ -1,0 +1,14 @@
+import { AbstractControl } from '@angular/forms';
+import { environment } from '../../../environments/environment';
+
+/**
+ * @description Validates fields against using 'agent_' in a key field for labels
+ * @param control AbstractControl
+ */
+export const disallowValidator = (control: AbstractControl): { [key: string]: boolean } => {
+    if (control.value.startsWith(environment.resources.disallowLabelEdit)) {
+        return { disallow: true }
+    }
+
+    return null;
+};

--- a/src/app/_shared/validators/keyvalue.validator.spec.ts
+++ b/src/app/_shared/validators/keyvalue.validator.spec.ts
@@ -1,0 +1,35 @@
+import { async } from '@angular/core/testing';
+import { keyPairValidator } from './keyvalue.validator';
+
+describe('keyPairValidator', () => {
+    let keyPairControl;
+    beforeEach(async(() => {
+        keyPairControl = (key: string, value: string) => ({
+            get: (field: string) => {
+                switch (field) {
+                    case 'key':
+                        return { value: key };
+                    case 'value':
+                        return { value: value };
+                }
+            }
+        })
+    }));
+
+    it('should create validator', () => {
+        expect(keyPairValidator).toBeTruthy();
+    });
+
+    it('should validate key pair', () => {
+        expect(keyPairValidator(keyPairControl('stuff', 'whatever'))).toEqual(null);
+    });
+
+    it('should invalidate missing key', () => {
+        expect(keyPairValidator(keyPairControl('', 'whatever'))).toEqual({ keyRequired: true });
+    });
+
+    it('should invalidate missing value', () => {
+        expect(keyPairValidator(keyPairControl('stuff', ''))).toEqual({ valRequired: true });
+    });
+
+});

--- a/src/app/_shared/validators/keyvalue.validator.ts
+++ b/src/app/_shared/validators/keyvalue.validator.ts
@@ -1,0 +1,16 @@
+import { AbstractControl } from '@angular/forms';
+
+export const keyPairValidator = (control: AbstractControl): { [key: string]: boolean } => {
+    const key = control.get('key').value;
+    const val = control.get('value').value;
+
+    if (key && !val) {
+        return { valRequired: true }
+    }
+
+    if (val && !key) {
+        return { keyRequired: true }
+    }
+
+    return null;
+};

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,4 @@
+/* Global styles */
+a.editclick {
+    cursor: pointer;
+}

--- a/src/environments/environment.mock.ts
+++ b/src/environments/environment.mock.ts
@@ -17,6 +17,9 @@ export const environment = {
     monitors: {
       pageSize: 25
     }
+  },
+  resources: {
+    disallowLabelEdit: 'agent_'
   }
 };
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -13,5 +13,8 @@ export const environment = {
     monitors: {
       pageSize: 25
     }
+  },
+  resources: {
+    disallowLabelEdit: 'agent_'
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -17,6 +17,9 @@ export const environment = {
     monitors: {
       pageSize: 25
     }
+  },
+  resources: {
+    disallowLabelEdit: 'agent_'
   }
 };
 


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-417

 ## Description:
Update Resource with Labels and Metadata. 
- Created a shared reusable component `add-fields.component`
- Added two new validators to shared module and used by `add-fields.component`

_NOTE_: There's an unexpected behavior with the Helix popover `<hx-popover>` it closes automatically when changes happen within the DOM and synthetic click events happen within the body of the popover. The Helix team is aware of this and haven't yet come to a solution, but have proposed workarounds. I think there's a workaround solution but I would need the time to go in deeper. 

Valdiation: 
- Cannot submit a key without a value
- Cannot submit a value without a key
- Labels - cannot use _agent_ in the key field

This is covered in great detail here:
https://rackspace.slack.com/archives/C1ZPBPYKZ/p1573480913000100
https://rackspace.slack.com/archives/C1ZPBPYKZ/p1573143685022700

 ## Testing:
`npm run test`

 ## Screenshots:

![updateMetaFields](https://user-images.githubusercontent.com/5041718/69169855-a82ff280-0abe-11ea-9e58-9e31e6a5294b.gif)

![updateLabel](https://user-images.githubusercontent.com/5041718/69169829-9ea68a80-0abe-11ea-83a3-b5a73c294455.gif)
