### PR TITLE
Monitor details read-only

### DIFF
--- a/localenv/routes/monitors.js
+++ b/localenv/routes/monitors.js
@@ -23,9 +23,16 @@ router.get('/', (req, res) => {
     });
 });
 
-
 router.get('/:id', (req, res) => {
-
+    let id = req.params.id;
+    axios.get(`${config.monitoring.api_host}${config.monitoring.api_url}/${Identity.info().token.tenant.id}/monitors/${id}`, {
+        headers: { 'x-auth-token': Identity.info().token.id }
+    }).then((data) => {
+        res.send(data.data);
+    })
+    .catch((err) => {
+        res.sendStatus(parseInt(err.response.status)).json(err);
+    });
 });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9298,6 +9298,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "core-js": "2.5.4",
     "hedwig-monitoring-library": "https://github.com/racker/Hedwig/archive/v1.0.0.tar.gz",
     "helix-ui": "0.18.0-rc.2",
+    "moment": "2.24.0",
     "rxjs": "6.3.3",
     "zone.js": "0.8.26"
   },
@@ -64,7 +65,7 @@
     "angular-in-memory-web-api": "0.7.0",
     "codelyzer": "4.5.0",
     "gulp": "4.0.0",
-    "http-server": "^0.11.1",
+    "http-server": "0.11.1",
     "jasmine-core": "2.99.1",
     "jasmine-spec-reporter": "4.2.1",
     "karma": "4.0.1",

--- a/src/app/_features/monitors/pages/details/monitor-details.page.html
+++ b/src/app/_features/monitors/pages/details/monitor-details.page.html
@@ -1,3 +1,4 @@
+<div *ngIf="monitor$ | async as monitor">
 <div class="hxRow monitor-header">
   <div class="hxCol hxSpan-12">
       <app-breadcrumb [routeDetails]="monitor.name"></app-breadcrumb>
@@ -35,8 +36,8 @@
 
   <div class="hxRow hxSpan-9">
     <div class="hxCol hxSpan-6">
-      <h4>Status</h4>
-      Active
+      <h4>Monitor Type</h4>
+      {{monitor.details.plugin.type}}
     </div>
     <div class="hxCol hxSpan-6">
       <h4>Labels</h4>
@@ -45,13 +46,27 @@
     </div>
   </div>
 
-  <div class="hxRow hxSpan-9 last-item">
+  <div class="hxRow hxSpan-9">
     <div class="hxCol hxSpan-6">
-      <h4>Monitor Type</h4>
-      {{monitor.type}}
+      <h4>Monitor Plugin Type</h4>
+      {{monitor.details.type}}
+    </div>
+    <div class="hxCol hxSpan-6">
+      <h4>Period (seconds)</h4>
+      {{monitor.interval | durationSeconds}}
     </div>
   </div>
 
+<div class="hxRow hxSpan-9 last-item">
+  <div class="hxCol hxSpan-6">
+    <h4>Last Updated</h4>
+    {{monitor.updatedTimestamp |  date:'MM/dd/yyyy'}}
+  </div>
+  <div class="hxCol hxSpan-6">
+    <h4>Created Date</h4>
+    {{monitor.createdTimestamp |  date:'MM/dd/yyyy'}}
+  </div>
+</div>
   <div class="hxRow hxSpan-9">
     <div class="hxCol">
       <h3>Events</h3>

--- a/src/app/_features/monitors/pages/details/monitor-details.page.html
+++ b/src/app/_features/monitors/pages/details/monitor-details.page.html
@@ -48,7 +48,7 @@
 
   <div class="hxRow hxSpan-9">
     <div class="hxCol hxSpan-6">
-      <h4>Monitor Plugin Type</h4>
+      <h4>Monitor Scope</h4>
       {{monitor.details.type}}
     </div>
     <div class="hxCol hxSpan-6">
@@ -59,11 +59,11 @@
 
 <div class="hxRow hxSpan-9 last-item">
   <div class="hxCol hxSpan-6">
-    <h4>Last Updated</h4>
+    <h4>Updated</h4>
     {{monitor.updatedTimestamp |  date:'MM/dd/yyyy'}}
   </div>
   <div class="hxCol hxSpan-6">
-    <h4>Created Date</h4>
+    <h4>Created</h4>
     {{monitor.createdTimestamp |  date:'MM/dd/yyyy'}}
   </div>
 </div>

--- a/src/app/_features/monitors/pages/details/monitor-details.page.spec.ts
+++ b/src/app/_features/monitors/pages/details/monitor-details.page.spec.ts
@@ -1,6 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientModule } from '@angular/common/http';
+import { SharedModule } from '../../../../_shared/shared.module';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { MonitorsPage } from '../monitors/monitors.page';
@@ -39,13 +41,14 @@ describe('MonitorDetailComponent', () => {
       declarations: [ MonitorDetailsPage ],
       imports: [
         HttpClientModule,
-        RouterTestingModule
+        RouterTestingModule,
+        SharedModule
       ],
       providers: [
         {
           provide: ActivatedRoute,
           useValue: {
-            params: of({id: 123}),
+            params: of({id: "anUniqueId"}),
             root: {
               routeConfig : routes[0]
             }
@@ -66,8 +69,13 @@ describe('MonitorDetailComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should setup defaults', () => {
+    expect(component.monitor$).toBeDefined();
+    expect(component.Object).toEqual(Object);
+  });
+
   it('should have a route param', () => {
-    expect(component.id).toEqual(123);
+    expect(component.id).toEqual("anUniqueId");
   });
 
   it('should declare Object', () => {
@@ -75,7 +83,8 @@ describe('MonitorDetailComponent', () => {
   });
 
   it('should set to a single monitor', () => {
-    let mocked = new monitorsMock().single;
-    expect(component.monitor).toEqual(mocked);
+    component.monitor$.subscribe((monitor) => {
+      expect(monitor).toEqual(new monitorsMock().single);
+    });
   });
 });

--- a/src/app/_features/monitors/pages/details/monitor-details.page.ts
+++ b/src/app/_features/monitors/pages/details/monitor-details.page.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MonitorService } from '../../../../_services/monitors/monitor.service';
+import { Observable } from 'rxjs';
+import { Monitor } from 'src/app/_models/monitors';
 
 declare const window: any;
 
@@ -10,21 +12,17 @@ declare const window: any;
   styleUrls: ['./monitor-details.page.scss']
 })
 export class MonitorDetailsPage implements OnInit {
-  id: number;
-  meta: {};
-  //TODO: create Interface for a single Monitor - will be mapped to
-  // service & response
-  monitor: any = {};
+  id: string;
+
+  monitor$: Observable<Monitor>;
   Object = window.Object;
 
   constructor(private route: ActivatedRoute, private monitorService: MonitorService) { }
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      this.id = +params['id'];
-      this.monitorService.getMonitor(this.id).subscribe(data => {
-        this.monitor = data;
-      });
+      this.id = params['id'];
+      this.monitor$ = this.monitorService.getMonitor(this.id);
     });
   }
 

--- a/src/app/_mocks/monitors/single.json
+++ b/src/app/_mocks/monitors/single.json
@@ -1,16 +1,21 @@
 {
-    "id": "10YN3Q45",
-    "name": "CPU Check",
+    "id": "23ONM715",
+    "name": "CPU System",
+    "labelSelectorMethod": "AND",
+    "interval": "30",
     "labelSelector": {
-        "additionalProp1": "LinuxOS",
-        "additionalProp2": "Prod",
-        "additionalProp3": "Load Balancer",
-        "additionalProp4": "amd64",
-        "additionalProp5": "Docker"
-
+        "additionalProp1": "EC2Instance",
+        "additionalProp2": "Dev",
+        "additionalProp3": "Node API",
+        "additionalProp4": "amd64"
     },
-    "type": "CPU",
     "details": {
-        "message": "dns1.stabletransit.com (IPv4):53"
-    }
+        "type": "local",
+        "plugin": {
+            "type": "network",
+            "additional": "add0"
+        }
+    },
+    "createdTimestamp": "2019-12-31T19:04:51Z",
+    "updatedTimestamp": "2020-01-03T18:50:16Z"
 }

--- a/src/app/_models/monitors.ts
+++ b/src/app/_models/monitors.ts
@@ -5,9 +5,9 @@ interface Label {
 export interface Monitor {
     id: string;
     name?: string;
+    labelSelectorMethod: string;
+    interval: string;
     labelSelector: Label;
-    labelSelectorMethod: string,
-    interval: string,
     details: {
         type: string,
         plugin: {

--- a/src/app/_services/monitors/monitor.service.spec.ts
+++ b/src/app/_services/monitors/monitor.service.spec.ts
@@ -26,9 +26,14 @@ describe('MonitorService', () => {
   });
 
   it('should set & get Monitors', () => {
-    service.monitors = {type: "legit"};
-    expect(service.monitors.type).toEqual("legit");
+    service.monitors = new monitorsMock().collection;
+    expect(service.monitors.content[0].id).toEqual("889EJ382");
   });
+
+  it('should set & get single Monitor', () => {
+    service.monitor = new monitorsMock().single;
+    expect(service.monitor.id).toEqual("23ONM715")
+  })
 
   describe('CRUD Operations', () => {
     it('should return collection', () => {
@@ -42,7 +47,7 @@ describe('MonitorService', () => {
     });
 
     it('should return single monitor', () => {
-      service.getMonitor(7).subscribe((data) => {
+      service.getMonitor("76kn92Mnnas-87mbVwq").subscribe((data) => {
         expect(data).toEqual(new monitorsMock().single);
       });
     });

--- a/src/app/_services/monitors/monitor.service.ts
+++ b/src/app/_services/monitors/monitor.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 import { LoggingService } from '../../_services/logging/logging.service';
 import { LogLevels } from '../../_enums/log-levels.enum';
 import { monitorsMock } from '../../_mocks/monitors/monitors.service.mock'
-import { Monitors } from 'src/app/_models/monitors';
+import { Monitors, Monitor } from 'src/app/_models/monitors';
 
 const httpOptions = {
   headers: new HttpHeaders({
@@ -19,17 +19,26 @@ const httpOptions = {
 })
 export class MonitorService {
 
-  private _monitors: {};
+  private _monitors: Monitors;
+  private _monitor: Monitor;
   private mockedMonitors = new monitorsMock();
 
   constructor(private http:HttpClient, private logService: LoggingService) { }
 
-  get monitors(): any {
+  get monitors(): Monitors {
     return this._monitors;
   }
 
-  set monitors(value: any) {
+  set monitors(value: Monitors) {
     this._monitors = value;
+  }
+
+  get monitor(): Monitor {
+    return this._monitor
+  }
+
+  set monitor(value: Monitor) {
+    this._monitor = value;
   }
 
   /**
@@ -57,14 +66,15 @@ export class MonitorService {
   }
 
 
-  getMonitor(id: number): Observable<any> {
+  getMonitor(id: string): Observable<Monitor> {
     if (environment.mock) {
-      return of(this.mockedMonitors.single);
+      return of<Monitor>(this.mockedMonitors.single);
     }
     else {
-      return this.http.get(`${environment.api.salus}/monitors/${id}`, httpOptions)
+      return this.http.get<Monitor>(`${environment.api.salus}/monitors/${id}`, httpOptions)
       .pipe(
         tap(data => {
+          this._monitor = data;
           this.logService.log(`Monitor: ${data}`, LogLevels.info);
         })
       );

--- a/src/app/_shared/pipes/duration-seconds.pipe.spec.ts
+++ b/src/app/_shared/pipes/duration-seconds.pipe.spec.ts
@@ -1,0 +1,18 @@
+import { DurationSecondsPipe } from './duration-seconds.pipe';
+
+describe('DurationSecondsPipe', () => {
+  let pipe: DurationSecondsPipe;
+
+  beforeEach(() => {
+    pipe = new DurationSecondsPipe();
+  })
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('convert ISO-8601 duration to seconds', () => {
+    let duration = "PT2M30S";
+    expect(pipe.transform(duration)).toEqual(150);
+  })
+});

--- a/src/app/_shared/pipes/duration-seconds.pipe.ts
+++ b/src/app/_shared/pipes/duration-seconds.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import * as moment from 'moment';
+
+@Pipe({
+  name: 'durationSeconds'
+})
+export class DurationSecondsPipe implements PipeTransform {
+  transform(value: string): number {
+    let duration = moment.duration(value);
+    return duration.asSeconds();
+  }
+}

--- a/src/app/_shared/shared.module.ts
+++ b/src/app/_shared/shared.module.ts
@@ -11,14 +11,16 @@ import { PaginationComponent } from './_components/pagination/pagination.compone
 import { MeasurementNamePipe } from './pipes/measurement-name.pipe';
 import { DeviceNamePipe } from './pipes/device-name.pipe';
 import { AddFieldsComponent } from './_components/add-fields/add-fields.component';
+import { DurationSecondsPipe } from './pipes/duration-seconds.pipe';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
   declarations: [
     BreadcrumbComponent,
     PaginationComponent,
-    MeasurementNamePipe,
     DeviceNamePipe,
+    DurationSecondsPipe,
+    MeasurementNamePipe,
     AddFieldsComponent
   ],
   imports: [
@@ -37,7 +39,8 @@ import { AddFieldsComponent } from './_components/add-fields/add-fields.componen
     PaginationComponent,
     AddFieldsComponent,
     MeasurementNamePipe,
-    DeviceNamePipe
+    DeviceNamePipe,
+    DurationSecondsPipe
   ],
   providers: [
     { provide: ErrorHandler, useClass: GlobalErrorHandler },


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-264

 ## Description:
Addition of monitor details - there will need to be a revisited focus on the _plugin_ details for each monitor plugin type when creating the update feature

 ## Testing:
`npm run test`

 ## Screenshots:
![monitorDetails](https://user-images.githubusercontent.com/5041718/72567435-80b99400-387b-11ea-98c1-6019eab51e8f.png)
