### PR TITLE
Modified test summary in describe block

### DIFF
--- a/e2e/src/features/monitoring/createmonitor/createNetworkMonitor.e2e-spec.ts
+++ b/e2e/src/features/monitoring/createmonitor/createNetworkMonitor.e2e-spec.ts
@@ -7,7 +7,7 @@ import { default as using } from "jasmine-data-provider";
 import { default as obj } from "../../../../Objects.json";
 
 
-describe("To test Network Monitor creation", () => {
+describe("To test Create Monitor functionality", () => {
     let page: AppPage;
     let nav: navigations;
   
@@ -22,7 +22,7 @@ describe("To test Network Monitor creation", () => {
     
     using([{monitorType:obj.monitordetails.monitorType1 ,monitorName:obj.monitordetails.monitorName1, key:obj.monitordetails.key1,value:obj.monitordetails.value1},{monitorType:obj.monitordetails.monitorType2 ,monitorName:obj.monitordetails.monitorName2,key:obj.monitordetails.key2,value:obj.monitordetails.value2}],(data)=>{
 
-      fit(`Verify that user must be navigated to Monitoring on creating ${data.monitorType} monitor`, () => {
+      it(`Verify that user must be navigated to Monitoring on creating ${data.monitorType} monitor`, () => {
       
         let page=new MonitorsListPage();
         page.createMonitorBtn.click();


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-502

 ## Description:
    -As a user Navigate to monitoring
    -Click on Create monitor button.
     -Select monitor type "Mem", fill the required data, and click on submit after monitor creation it must navigate to monitoring and new monitor should listed in the monitor grid.
 ## Testing:
npm run test:e2e

 ## Screenshots:
(if applicable)