### PR TITLE
Adding testcases of AdminEventDetails-MNRVA-554

### DIFF
--- a/e2e/src/commons/navigations.ts
+++ b/e2e/src/commons/navigations.ts
@@ -36,6 +36,11 @@ export class navigations
       expect(element(by.xpath("//a[contains(text(),'Visualize')]")).isPresent()).toBe(true);
      
    }
+
+
+   navigateToAdmin(){
+     element(by.xpath("//a[contains(text(),'Admin')]")).click();
+   }
   
   async loadresources()
   {

--- a/e2e/src/features/admin/displayEventDetails.e2e-spec.ts
+++ b/e2e/src/features/admin/displayEventDetails.e2e-spec.ts
@@ -5,10 +5,8 @@ import { MonitorsDetailsPage } from "../../pages/monitordetailspage";
 import { browser, Key, element, by } from "protractor";
 import { EventDetailsPage } from "../../pages/eventDetailspage";
 import { default as event } from "../../../../src/app/_mocks/events/getAllEvents.json";
-import { DatePipe } from "@angular/common";
 
-
-describe("Test to update dynamic plugin data", ()=> {
+describe("Test display of event details", ()=> {
     let page : AppPage;
     let nav  : navigations;
     let page1: MonitorsListPage;
@@ -48,8 +46,8 @@ describe("Test to update dynamic plugin data", ()=> {
        expect(page3.eventNameHeader('cpu').getText()).toEqual(event.content[0].name);
        expect(page3.monitorType.getText()).toEqual(event.content[0].name);
        expect(page3.agentEnvironment.getText()).toEqual(event.content[0].taskParameters.labelSelector.agent_environment);
-       expect(page3.createdDate.getText()).toEqual(page3.dateConversionForCreatedTimestamp());
-       expect(page3.LastUpdated.getText()).toEqual(page3.dateConversionForUpdatedTimestamp());
+       expect(page3.createdDate.getText()).toEqual(page3.dateConversion(event.content[0].createdTimestamp));
+       expect(page3.LastUpdated.getText()).toEqual(page3.dateConversion(event.content[0].updatedTimestamp));
     
       });
 });

--- a/e2e/src/features/admin/displayEventDetails.e2e-spec.ts
+++ b/e2e/src/features/admin/displayEventDetails.e2e-spec.ts
@@ -1,0 +1,55 @@
+import { AppPage } from "../../pages/app.po";
+import { navigations } from "../../commons/navigations";
+import { MonitorsListPage } from "../../pages/monitorlistpage";
+import { MonitorsDetailsPage } from "../../pages/monitordetailspage";
+import { browser, Key, element, by } from "protractor";
+import { EventDetailsPage } from "../../pages/eventDetailspage";
+import { default as event } from "../../../../src/app/_mocks/events/getAllEvents.json";
+import { DatePipe } from "@angular/common";
+
+
+describe("Test to update dynamic plugin data", ()=> {
+    let page : AppPage;
+    let nav  : navigations;
+    let page1: MonitorsListPage;
+    let page2: MonitorsDetailsPage;
+    
+ 
+    beforeAll(() => {
+       page = new AppPage();
+       page.navigateTo();
+       browser.manage().window().maximize();
+    });
+ 
+    beforeEach(() => {
+       nav = new navigations();
+       nav.navigateToAdmin();
+       browser.sleep(5000);
+       page1 = new MonitorsListPage();
+       page1.monitorName().click();
+       browser.sleep(3000);
+       page2 = new MonitorsDetailsPage();
+ 
+     });
+
+     it("To verify details of a selected event",()=>{
+       
+       page2.eventName('cpu').click();
+       let page3=new EventDetailsPage();
+       
+       //check the display of event fields
+       expect(page3.pageTitle().isDisplayed()).toBe(true);
+       expect(page3.labelMonitorType.isDisplayed()).toBe(true);
+       expect(page3.labelagentEnvironment.isDisplayed()).toBe(true);
+       expect(page3.labelCreatedDate.isDisplayed()).toBe(true);
+       expect(page3.labelLastUpdated.isDisplayed()).toBe(true);
+       
+       //check the display of event values
+       expect(page3.eventNameHeader('cpu').getText()).toEqual(event.content[0].name);
+       expect(page3.monitorType.getText()).toEqual(event.content[0].name);
+       expect(page3.agentEnvironment.getText()).toEqual(event.content[0].taskParameters.labelSelector.agent_environment);
+       expect(page3.createdDate.getText()).toEqual(page3.dateConversionForCreatedTimestamp());
+       expect(page3.LastUpdated.getText()).toEqual(page3.dateConversionForUpdatedTimestamp());
+    
+      });
+});

--- a/e2e/src/features/monitoring/monitordetails/updateDynamicPluginData.e2e-spec.ts
+++ b/e2e/src/features/monitoring/monitordetails/updateDynamicPluginData.e2e-spec.ts
@@ -5,7 +5,6 @@ import { MonitorsDetailsPage } from "../../../pages/monitordetailspage";
 import { browser, Key, element, by } from "protractor";
 import { UpdatePluginDataOverlay } from "../../../overlays/updateplugindataOverlay";
 import { protractor } from "protractor/built/ptor";
-import { elementEventFullName } from "@angular/compiler/src/view_compiler/view_compiler";
 
 describe("Test to update dynamic plugin data", ()=> {
     let page : AppPage;

--- a/e2e/src/pages/eventDetailspage.ts
+++ b/e2e/src/pages/eventDetailspage.ts
@@ -14,9 +14,6 @@ export class EventDetailsPage{
     createdDate           =element(by.xpath("//div[@id='valueCreatedDate']"));
     LastUpdated           =element(by.xpath("//div[@id='valueLast']"));
 
-    // constructor(private datepipe: DatePipe){
-    // }
-
 
     pageTitle(){
         
@@ -27,20 +24,9 @@ export class EventDetailsPage{
         return(element(by.xpath("//h2[contains(text(),'"+event+"')]")));
     }
 
-    dateConversionForCreatedTimestamp(){
+    dateConversion(timestamp:string){
         const datepipe: DatePipe = new DatePipe('en-US');
-        let srcDate=event.content[0].createdTimestamp;
-        let latest_date =datepipe.transform(srcDate, 'MM/dd/yyyy');
-        return latest_date;
-
-    }
-
-    dateConversionForUpdatedTimestamp(){
-        const datepipe: DatePipe = new DatePipe('en-US');
-        let srcDate=event.content[0].updatedTimestamp;
-        let latest_date =datepipe.transform(srcDate, 'MM/dd/yyyy');
-        return latest_date;
-
+        return datepipe.transform(timestamp, 'MM/dd/yyyy');
     }
 
 

--- a/e2e/src/pages/eventDetailspage.ts
+++ b/e2e/src/pages/eventDetailspage.ts
@@ -1,0 +1,47 @@
+import { element, by } from "protractor";
+import { DatePipe } from "@angular/common";
+import { default as event } from "../../../src/app/_mocks/events/getAllEvents.json";
+
+
+export class EventDetailsPage{
+
+    labelMonitorType      =element(by.id('lblMonitorType'));
+    labelagentEnvironment =element(by.id('label.key'));  
+    labelCreatedDate      =element(by.id("lblCreatedDate"));
+    labelLastUpdated      =element(by.id('lblLast'));
+    monitorType           =element(by.xpath("//div[@id='valueMontyp']"));
+    agentEnvironment      =element(by.xpath("//div[@id='localdev']"));
+    createdDate           =element(by.xpath("//div[@id='valueCreatedDate']"));
+    LastUpdated           =element(by.xpath("//div[@id='valueLast']"));
+
+    // constructor(private datepipe: DatePipe){
+    // }
+
+
+    pageTitle(){
+        
+        return(element(by.xpath("//h3[contains(text(),'Event Details')]")));
+    }
+
+    eventNameHeader(event:string){
+        return(element(by.xpath("//h2[contains(text(),'"+event+"')]")));
+    }
+
+    dateConversionForCreatedTimestamp(){
+        const datepipe: DatePipe = new DatePipe('en-US');
+        let srcDate=event.content[0].createdTimestamp;
+        let latest_date =datepipe.transform(srcDate, 'MM/dd/yyyy');
+        return latest_date;
+
+    }
+
+    dateConversionForUpdatedTimestamp(){
+        const datepipe: DatePipe = new DatePipe('en-US');
+        let srcDate=event.content[0].updatedTimestamp;
+        let latest_date =datepipe.transform(srcDate, 'MM/dd/yyyy');
+        return latest_date;
+
+    }
+
+
+}

--- a/e2e/src/pages/monitordetailspage.ts
+++ b/e2e/src/pages/monitordetailspage.ts
@@ -10,8 +10,13 @@ export class MonitorsDetailsPage
    updatePluginDataPencilIcon =element(by.xpath("//hx-icon[@id='pencilIcn']"));
    dynamicPluginDataPopover   =element(by.xpath("//div[@id='updateForm']"));
    monitorTypeMonitorDetails  =element(by.xpath("//h4[contains(text(),'net_response monitor Details')]"));
+  
 
 
+  eventName(event:string){
+    return(element(by.xpath("//a[contains(text(),'"+event+"')]")));
+  }
+  
   labelsInfoKeyDisplay(key:string){
      return(element(by.xpath("//div[contains(text(),'"+key+"')]")));
      


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-554

 ## Description:
     As user i would like to see event details.

-Navigate to Admin section
-Monitor tab should be selected and select a monitor and navigate to monitor details.
-Select an event form event grid.
-Should navigate to Event details page and show Event details page along with Event details.

 ## Testing:
     npm run test:e2e

 ## Screenshots:
(if applicable)