### PR TITLE
Maximum call stack size exceeded.

### DIFF
--- a/src/app/_features/monitors/mon.utils.spec.ts
+++ b/src/app/_features/monitors/mon.utils.spec.ts
@@ -4,11 +4,13 @@ import {
     CreateMonitor
 } from 'src/app/_models/salus.monitor'
 import { Monitor } from 'src/app/_models/monitors';
+import { BoundMonitor, CreateResource } from 'src/app/_models/resources';
 import { CreateTestMonitor } from 'src/app/_features/monitors/interfaces/testMonitor.interface'
 
 describe('Monitor Utilities', () => {
 
     let newMonitor: CreateMonitor;
+    let newBoundmonitor:CreateResource;
     let schemaMonitor;
     beforeEach(async(() => {
         newMonitor = {
@@ -162,6 +164,24 @@ describe('Monitor Utilities', () => {
         expect(MonitorUtil.formatSummaryField(monitor)).toEqual("ping-tcp-f2c14");
         monitor.summary = {};
         expect(MonitorUtil.formatSummaryField(monitor)).toEqual("ping-f2c14");
+    });
+
+
+    it('should create bound monitor tag', () => {
+        let boundMonitor: BoundMonitor = Object.assign({
+            monitorId: "423b0924-fbe8-4820-8529-c361e5ec9346",
+            monitorType: "ping",
+            monitorName: "",
+            resourceId: "jjb-test",
+            interval: "PT1M6S",
+            selectorScope: "REMOTE",
+            agentType: "TELEGRAF",
+            renderedContent: "",
+            envoyId:"",
+            createdTimestamp: "2020-08-21T16:43:23Z",
+            updatedTimestamp: "2020-08-27T20:12:59Z",
+        }, newBoundmonitor);
+        expect(MonitorUtil.formatTitleField(boundMonitor)).toEqual("ping-c9346");
     });
 
     it('should create a formatted test monitor', () => {

--- a/src/app/_features/monitors/mon.utils.ts
+++ b/src/app/_features/monitors/mon.utils.ts
@@ -1,6 +1,8 @@
 import { FieldConfig, Validator } from './interfaces/field.interface';
 import { Validators } from '@angular/forms';
 import { Monitor } from 'src/app/_models/monitors';
+import { BoundMonitor } from 'src/app/_models/resources';
+
 import { CreateTestMonitor } from './interfaces/testMonitor.interface';
 
 export enum CntrlAttribute {
@@ -195,6 +197,10 @@ export class MonitorUtil {
         }else{
             return `${monitor.details.plugin.type}-${monitor.id.substr(monitor.id.length - 5)}`;
         }
+    }
+
+    static formatTitleField(monitor: BoundMonitor) {
+        return `${monitor.monitorType}-${monitor.monitorId.substr(monitor.monitorId.length - 5)}`;
     }
 
     static formatTestMonitor(resourceId, monitor: Monitor): CreateTestMonitor {

--- a/src/app/_features/resources/components/monitor_list/monitor-list.component.html
+++ b/src/app/_features/resources/components/monitor_list/monitor-list.component.html
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let monitor of monitors">
-        <td [id]="monitor.monitorId"><a [routerLink]="['/monitors/details', monitor.monitorId]">{{monitor.monitorName }}</a></td>
+        <td [id]="monitor.monitorId"><a [routerLink]="['/monitors/details', monitor.monitorId]">{{monitor.monitorName || monitor.monitorType }}</a></td>
 
         <td >{{monitor.monitorType}}</td>
         <td>{{monitor.selectorScope}}</td>

--- a/src/app/_features/resources/components/monitor_list/monitor-list.component.html
+++ b/src/app/_features/resources/components/monitor_list/monitor-list.component.html
@@ -9,8 +9,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let monitor of monitors">
-        <td [id]="monitor.monitorId"><a [routerLink]="['/monitors/details', monitor.monitorId]">{{monitor.monitorName || monitor.monitorType }}</a></td>
-
+        <td [id]="monitor.monitorId"><a [routerLink]="['/monitors/details', monitor.monitorId]">{{monitor.monitorName || monitorUtil.formatTitleField(monitor) }}</a></td>
         <td >{{monitor.monitorType}}</td>
         <td>{{monitor.selectorScope}}</td>
       </tr>


### PR DESCRIPTION
 **JIRA:**
See ticket here - https://jira.rax.io/browse/MNRVA-562

**Description:**

1. Remove function which is broken as summary obj is not coming in api call.
2. As per discussion, only monitorType is a field which can be used in place of monitorName when the same is empty in some cases.

**Testing:**

`npm run test:unit`

 ## Screenshots:
(if applicable)