### PR TITLE
Create a way to separate the Admin build from Minerva

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Run `ng generate component <component-name>` to generate a new component. You ca
 ## Build
 
 
-Run `npm run build`. it will run `makefile build-frontend` to execute makefile file which contains a set of directives used by a make build automation tool to generate specified goal.
+Run `npm run build`. it will run `makefile build-frontend` to execute `makefile` file. `makefile` is a file containing a set of directives used by a make build automation tool to generate specified goal.
 
-`makefile` execute two commands `ng build --project='minerva'` & `ng build --project='admin'` and generates two build folders. The build artifacts will be stored in the `dist/` directory. `--project='minerva'` context actually tell us which project to build as it interacts with angular.json and look for project name specified inside      `projects` object.  
+`makefile` execute two commands `ng build --project='minerva'` & `ng build --project='admin'` and generates two different builds named `admin` & `minerva`. The build artifacts will be stored in the `dist/` directory. The `--project='minerva'` context actually tells which project we are going to build as it internally interacts with the `angular.json` and look for the project name specified inside `projects` object.  
 
 ## Running unit tests
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Run `ng generate component <component-name>` to generate a new component. You ca
 
 ## Build
 
-Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+
+Run `npm run build`. it will run `makefile build-frontend` to execute makefile file which contains a set of directives used by a make build automation tool to generate specified goal.
+
+`makefile` execute two commands `ng build --project='minerva'` & `ng build --project='admin'` and generates two build folders. The build artifacts will be stored in the `dist/` directory. `--project='minerva'` context actually tell us which project to build as it interacts with angular.json and look for project name specified inside      `projects` object.  
 
 ## Running unit tests
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,7 @@
+help:
+	@echo "_______BUILD ANGULAR FRONTEND______\n"
+	@echo "To build all apps run make make build-frontend"
+
+build-frontend:
+	ng build --project='minerva' &&\
+	ng build --project='admin' 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ng": "ng",
     "start": "ng serve --public-host dev.i.rax.io --baseHref=/intelligence -o",
     "start:mock": "ng serve -c mock --baseHref=/intelligence --public-host dev.i.rax.io -o",
-    "build": "ng build --watch",
+    "build": "make build-frontend",
     "build:mock": "ng build --watch -c=mock",
     "test:unit": "node ./localenv/helpers/createMocks.js && ng test --project=minerva -c=mock --watch=false",
     "test:unit-ci": "ng test --project=minerva -c=mock --watch=false",

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -13,6 +13,7 @@ const providers = [AuthGuardService]
   ],
   imports: [
     AppRoutingModule,
+    BrowserModule
    // SharedModule
   ],
   providers: providers,

--- a/projects/admin/src/app/app.module.ts
+++ b/projects/admin/src/app/app.module.ts
@@ -13,7 +13,6 @@ const providers = [AuthGuardService]
   ],
   imports: [
     AppRoutingModule,
-    BrowserModule
    // SharedModule
   ],
   providers: providers,


### PR DESCRIPTION
**JIRA:**
See ticket here - https://jira.rax.io/browse/MNRVA-565

**Description:**

1) Create makefile - a file which is used for creating multiple builds using make inbuilt automation tool in CLI
2) create two build folders with name Minerva and Admin inside Dist folder.

**Testing:**

`npm run test:unit`

 ## Screenshots:
(if applicable)