### PR TITLE
Admin layout mnrva 506

### DIFF
--- a/e2e/src/features/admin/adminLayout.e2e-spec.ts
+++ b/e2e/src/features/admin/adminLayout.e2e-spec.ts
@@ -1,0 +1,36 @@
+import { AppPage } from "../../pages/app.po";
+import { navigations } from "../../commons/navigations";
+import { browser } from "protractor";
+import { AdminToolsPage } from "../../pages/adminToolsPage";
+
+
+
+
+describe("Test layout of admin tools", ()=> {
+    let page : AppPage;
+    let nav  : navigations;
+    let page1: AdminToolsPage;
+
+    
+ 
+    beforeAll(() => {
+       page = new AppPage();
+       page.navigateTo();
+       browser.manage().window().maximize();
+    });
+ 
+    beforeEach(() => {
+       nav = new navigations();
+       nav.navigateToAdmin();
+       page1=new AdminToolsPage();
+
+    });
+
+    it("To test admin section of Minerva have the general layout of monitoring.rackspace.net",()=>{
+       expect(page1.accountSearchBox.isDisplayed()).toBe(true);
+       expect(page1.monitorsTab.isDisplayed()).toBe(true);
+       expect(page1.resourcesTab.isDisplayed()).toBe(true);
+
+});
+
+});

--- a/e2e/src/pages/adminToolsPage.ts
+++ b/e2e/src/pages/adminToolsPage.ts
@@ -1,0 +1,9 @@
+import { element, by, browser, protractor } from "protractor";
+
+export class AdminToolsPage{
+    
+    accountSearchBox = element(by.xpath("//input[@placeholder='Account Search']"));
+    monitorsTab      = element(by.xpath("//hx-tab[contains(text(),'Monitors')]"));
+    resourcesTab     = element(by.xpath("//hx-tab[contains(text(),'Resources')]"));
+
+}


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-506

 ## Description:
      As a team, we'd like the /admin section of Minerva to have the general layout of monitoring.rackspace.net
      AC: Search box and tabs are viewable in the admin section
  1.Navigate to Admin
  2.there should be the search box, monitor, and resource tab.

 ## Testing:
 npm run test:e2e

 ## Screenshots:
(if applicable)