### PR TITLE
Delete monitor: tweak UI for modal pop  

### DIFF
--- a/src/app/_features/monitors/components/list/monitorslist.component.html
+++ b/src/app/_features/monitors/components/list/monitorslist.component.html
@@ -30,14 +30,8 @@
         <hx-progress value="{{progressVal}}"></hx-progress>
       </hx-div>
     </div>
-    <hx-alert type="success">  {{ this.successCount }} out of {{ selectedMonForDeletion.length }} is/are deleted successfully!
+    <hx-alert #hxAlert type="success" persist>  {{ this.successCount }} out of {{ selectedMonForDeletion.length }} were deleted successfully!
     </hx-alert>
-      <div *ngFor="let selectedMonitor of selectedMonForDeletion">
-        <hx-alert *ngIf="selectedMonitor?.error"
-        type="error">
-        {{selectedMonitor.monitor.name || monitorUtil.formatSummaryField(selectedMonitor.monitor)}}
-      </hx-alert>
-      </div>
     <footer>
       <button id="triggerOk" class="hxBtn hxPrimary"(click)="triggerOk()" [disabled]="disableOk">Ok</button>
     </footer>

--- a/src/app/_features/monitors/components/list/monitorslist.component.html
+++ b/src/app/_features/monitors/components/list/monitorslist.component.html
@@ -30,10 +30,13 @@
         <hx-progress value="{{progressVal}}"></hx-progress>
       </hx-div>
     </div>
+    <hx-alert type="success">  {{ this.successCount }} out of {{ selectedMonForDeletion.length }} is/are deleted successfully!
+    </hx-alert>
       <div *ngFor="let selectedMonitor of selectedMonForDeletion">
-      <hx-div [ngClass]="selectedMonitor?.error ? 'hxDivErr' : 'hxDivSuccess'">
+        <hx-alert *ngIf="selectedMonitor?.error"
+        type="error">
         {{selectedMonitor.monitor.name || monitorUtil.formatSummaryField(selectedMonitor.monitor)}}
-      </hx-div>
+      </hx-alert>
       </div>
     <footer>
       <button id="triggerOk" class="hxBtn hxPrimary"(click)="triggerOk()" [disabled]="disableOk">Ok</button>

--- a/src/app/_features/monitors/components/list/monitorslist.component.html
+++ b/src/app/_features/monitors/components/list/monitorslist.component.html
@@ -30,7 +30,7 @@
         <hx-progress value="{{progressVal}}"></hx-progress>
       </hx-div>
     </div>
-    <hx-alert #hxAlert type="success" persist>  {{ this.successCount }} out of {{ selectedMonForDeletion.length }} were deleted successfully!
+    <hx-alert type="success" persist>  {{ this.successCount }} out of {{ selectedMonForDeletion.length }} were deleted successfully!
     </hx-alert>
     <footer>
       <button id="triggerOk" class="hxBtn hxPrimary"(click)="triggerOk()" [disabled]="disableOk">Ok</button>

--- a/src/app/_features/monitors/components/list/monitorslist.component.scss
+++ b/src/app/_features/monitors/components/list/monitorslist.component.scss
@@ -18,20 +18,6 @@
     text-transform: lowercase;
 }
 
-:host > #hxClose {
-    display: none !important;
-}
-
- 
-
-:host > #hxDismiss {
-    flex-shrink: 0;
-    height: 3rem;
-    padding: 1rem;
-    width: 3rem;
-    display: none !important;
-}
-
 hx-alert[type="success"] {
     color: #4caf51 !important;
     background-color: #ffffff !important;

--- a/src/app/_features/monitors/components/list/monitorslist.component.scss
+++ b/src/app/_features/monitors/components/list/monitorslist.component.scss
@@ -17,3 +17,27 @@
     white-space: pre-line;
     text-transform: lowercase;
 }
+
+:host > #hxClose {
+    display: none !important;
+}
+
+ 
+
+:host > #hxDismiss {
+    flex-shrink: 0;
+    height: 3rem;
+    padding: 1rem;
+    width: 3rem;
+    display: none !important;
+}
+
+hx-alert[type="success"] {
+    color: #4caf51 !important;
+    background-color: #ffffff !important;
+}
+
+hx-alert[type="error"] {
+    color: #d32f2f !important;
+    background-color: #ffffff !important;
+}

--- a/src/app/_features/monitors/components/list/monitorslist.component.spec.ts
+++ b/src/app/_features/monitors/components/list/monitorslist.component.spec.ts
@@ -11,6 +11,9 @@ import { MonitorUtil } from '../../mon.utils';
 import { PaginationComponent } from 'src/app/_shared/components/pagination/pagination.component';
 import { mockResourcesProvider } from 'src/app/_interceptors/request.interceptor';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { LoggingService } from 'src/app/_services/logging/logging.service';
+import { of } from 'rxjs';
+
 
 var mockMonitor: Monitor = {
   "id": "76WE85UV",
@@ -38,6 +41,7 @@ describe('MonitorslistComponent', () => {
   let component: MonitorslistComponent;
   let fixture: ComponentFixture<MonitorslistComponent>;
   let monitorService: MonitorService;
+  let logService: LoggingService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -58,6 +62,7 @@ describe('MonitorslistComponent', () => {
     fixture = TestBed.createComponent(MonitorslistComponent);
     component = fixture.componentInstance;
     monitorService = injector.get(MonitorService);
+    logService      = injector.get(LoggingService);
     component.ngOnInit();
     fixture.detectChanges();
   }));
@@ -223,6 +228,13 @@ describe('MonitorslistComponent', () => {
     });
 
   });
+
+  fit('should check failedMonitors array', () => {
+    component.failedMonitors = ["lovedeep-2", "lovedeep-1"];
+    let spy = spyOn(logService, 'log');
+    component.triggerOk();
+    expect(spy).toHaveBeenCalled();
+  })
 
 
 

--- a/src/app/_features/monitors/components/list/monitorslist.component.spec.ts
+++ b/src/app/_features/monitors/components/list/monitorslist.component.spec.ts
@@ -229,7 +229,7 @@ describe('MonitorslistComponent', () => {
 
   });
 
-  fit('should check failedMonitors array', () => {
+  it('should check failedMonitors array', () => {
     component.failedMonitors = ["lovedeep-2", "lovedeep-1"];
     let spy = spyOn(logService, 'log');
     component.triggerOk();

--- a/src/app/_features/monitors/components/list/monitorslist.component.ts
+++ b/src/app/_features/monitors/components/list/monitorslist.component.ts
@@ -22,6 +22,7 @@ export class MonitorslistComponent implements OnInit {
   monitors: any[];
   total: number;
   page: number = 0;
+  successCount: number = 0;
   progressVal: number = 0;
   disableOk: boolean = true;
   modalType : string = 'delMonitorModal';
@@ -212,6 +213,7 @@ export class MonitorslistComponent implements OnInit {
     this.delMonitor.nativeElement.click();
     this.selectedMonitors.forEach((element, index) => {
         var id = this.monitorService.deleteMonitorPromise(element.id).then((resp) => { 
+            this.successCount++;
             this.progressBar(index++, {monitor:this.monitors.filter(a => a.id === element.id)[0], error: false});
         }).catch(err => {
             this.progressBar(index++, {monitor:this.monitors.filter(a => a.id === element.id)[0], error: true});

--- a/src/app/_features/monitors/components/list/monitorslist.component.ts
+++ b/src/app/_features/monitors/components/list/monitorslist.component.ts
@@ -20,7 +20,6 @@ export class MonitorslistComponent implements OnInit {
   @ViewChild('confirmMonitor') confirmMonitor:ElementRef;
   @ViewChild('delMonitorLink') delMonitor:ElementRef;
   @ViewChild('chkColumn') chkColumn:ElementRef;
-  @ViewChild('hxAlert') hxAlert:ElementRef;
 
   monitorSearchPlaceholderText: string;
   monitors: any[];

--- a/src/app/_features/monitors/components/list/monitorslist.component.ts
+++ b/src/app/_features/monitors/components/list/monitorslist.component.ts
@@ -112,15 +112,15 @@ export class MonitorslistComponent implements OnInit {
    * @returns void
    */
   checkColumn(event) {
+    this.monitors.forEach(e => {
+      e["checked"] = event.target.checked;
+    });
     if (event.target.checked) {
       this.selectedMonitors = this.monitors.map(x => Object.assign({}, x));
     }
     else {
       this.selectedMonitors = [];
     }
-    this.monitors.forEach(e => {
-      e["checked"] = event.target.checked;
-    });
   }
 
   /**
@@ -154,13 +154,20 @@ export class MonitorslistComponent implements OnInit {
    * @param monitor Monitor
    */
   selectMonitors(monitor: Monitor) {
-    if (this.selectedMonitors.indexOf(monitor) === -1) {
+    if (this.checkExist(this.selectedMonitors, monitor.id) === false) {
       this.selectedMonitors.push(monitor);
     } else {
       this.selectedMonitors.splice(
-        this.selectedMonitors.indexOf(monitor), 1
+        this.selectedMonitors.map(value => value.id === monitor.id), 1
       );
     }
+  }
+
+  checkExist(arr, id) {
+    const { length } = arr;
+    const len = length + 1;
+    const found = arr.some(el => el.id === id);
+    return found;
   }
 
     /**
@@ -195,6 +202,7 @@ export class MonitorslistComponent implements OnInit {
       this.failedMonitors.join(' , ');
       this.logService.log(this.failedMonitors + ' failed deletion', LogLevels.error); 
     }
+    this.successCount = 0;
   }
 
   /**
@@ -227,7 +235,6 @@ export class MonitorslistComponent implements OnInit {
         }).catch(err => {           
             this.failedMonitors.push(element.name);
             this.progressBar(index++, {monitor:this.monitors.filter(a => a.id === element.id)[0], error: true});
-
         });
         this.monitorArr.push(id);
     })


### PR DESCRIPTION
**JIRA:**
See ticket here - https://jira.rax.io/browse/MNRVA-582

**Description:**
1) We need to show error and success icon according to the response coming from an api when you delete any monitor.
2) if monitor is deleted then the Alert icon should show in the modal popup
3) If a monitor is deleted then the Success icon should show in a modal popup.

**Testing:**

npm run test:unit

**Screenshots:
<img width="1792" alt="Screenshot 2020-10-21 at 12 12 34 AM" src="https://user-images.githubusercontent.com/66314110/96915612-11389b00-14c4-11eb-987e-ce2657189ae8.png">
**
(if applicable)