### PR TITLE
Spinner resize overlay area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2628,12 +2628,14 @@
     "allure-commandline": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.13.0.tgz",
-      "integrity": "sha512-KUByc0nT+vVVsnW/p36R92+FS2o3xVX27p+AW/8T4dlXVh7jx6V0v6+rRBCpK7AhBKD9/T3jsSq14hS0sxp64Q=="
+      "integrity": "sha512-KUByc0nT+vVVsnW/p36R92+FS2o3xVX27p+AW/8T4dlXVh7jx6V0v6+rRBCpK7AhBKD9/T3jsSq14hS0sxp64Q==",
+      "dev": true
     },
     "allure-js-commons": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-1.3.2.tgz",
       "integrity": "sha512-FTmoqP36ZjHFT4iLdYamyCFhyj1jqD6BIdiZ5pBlyafDJrFRV76XIXNxwRqbHpSw40o1vHzYi4vGpmREnhnHVw==",
+      "dev": true,
       "requires": {
         "file-type": "^7.7.1",
         "fs-extra": "^6.0.1",
@@ -2647,6 +2649,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
           "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -2656,7 +2659,8 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
         }
       }
     },
@@ -6460,7 +6464,8 @@
     "file-type": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ==",
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -6987,7 +6992,8 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -8426,6 +8432,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jasmine-allure-reporter/-/jasmine-allure-reporter-1.0.2.tgz",
       "integrity": "sha512-L3+XQ13xRfESbbdp1tii/OomW65xwTCgp66fKH1UxWK8L0j07G0s9/tYl+G7HdtbG76CYM807qj5nFDu7C9oBA==",
+      "dev": true,
       "requires": {
         "allure-js-commons": "^1.3.1"
       }
@@ -8511,6 +8518,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
       "requires": {
         "xmlcreate": "^1.0.1"
       }
@@ -8566,6 +8574,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -14842,7 +14851,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unix-crypt-td-js": {
       "version": "1.1.4",
@@ -15904,7 +15914,8 @@
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8="
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/src/app/_features/resources/components/list/resourceslist.component.ts
+++ b/src/app/_features/resources/components/list/resourceslist.component.ts
@@ -29,7 +29,7 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
   message   : string = 'Are you sure you want to delete selected resource?';
   confirmMessageSuccess : string = "";
   confirmMessageError : string = "";
-  
+
   resources: Resource[];
   failedResources:any = [];
   total: number;
@@ -43,15 +43,15 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
   fetchResources: any;
   addResLoading: boolean = false;
   isDescending:boolean = true;
-  disableOk: boolean = true;  
+  disableOk: boolean = true;
   selectedResources: any = [];
   selectedResForDeletion:any = [];
   resourceArr:any = [];
   addResourceForm: FormGroup;
   constructor(private resourceService: ResourcesService,
-    private validateResource: ValidateResource, 
+    private validateResource: ValidateResource,
     private fb: FormBuilder,
-    private router: Router, private spnService: SpinnerService, 
+    private router: Router, private spnService: SpinnerService,
     private logService: LoggingService, private env: EnvironmentConfig) {
       this.spnService.changeLoadingStatus(true);
       this.defaultAmount= env.pagination.pageSize;
@@ -103,12 +103,12 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
    * @description sort resources used for sorting the resource list by passing params this.sorting.
    * @param orderBy string
    * @param sortBy string
-  */  
+  */
   sortResources(orderBy, sortBy) {
     this.isDescending = !this.isDescending;
     this.sorting = sortBy + ',' + orderBy;
     this.fetchResources();
-    this.spnService.changeLoadingStatus(true);   
+    this.spnService.changeLoadingStatus(true);
   }
 
   /**
@@ -226,8 +226,8 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
 
   /**
    * @description function called when to close confirmation modal as customer don't want to delete selected resources.
-   * @param flag 
-   * 
+   * @param flag
+   *
    */
 
   triggerClose(flag) {
@@ -238,22 +238,22 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
   /**
    * @description function called when to close progress bar modal by click on OK button.
    * open and close attributes are used to open and close modal.
-   * 
+   *
    */
 
   triggerOk() {
-    if(this.chkColumnRs.nativeElement.checked) 
-    this.reset();  
-    this.confirmResource.nativeElement.removeAttribute("open");   
+    if(this.chkColumnRs.nativeElement.checked)
+    this.reset();
+    this.confirmResource.nativeElement.removeAttribute("open");
     this.confirmResource.nativeElement.setAttribute("close", "true");
     this.selectedResources.map(item => {
       this.resources = this.resources.filter(a => a.resourceId !== item.resourceId);
-    });  
+    });
     this.selectedResources = [];
     this.fetchResources();
     if(this.failedResources.length > 0) {
       this.failedResources.join(' , ');
-      this.logService.log(this.failedResources + ' failed deletion', LogLevels.error); 
+      this.logService.log(this.failedResources + ' failed deletion', LogLevels.error);
     }
     this.successCount = 0;
   }
@@ -261,7 +261,7 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
   reset() {
     this.resources.forEach(e => {
       if(e.checked)
-        e.checked = false;    
+        e.checked = false;
       });
       this.chkColumnRs.nativeElement.checked = false;
 
@@ -271,7 +271,7 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
    * @description Function called after confirm delete. selectedResources are list of resources selected for deletion.
    * resourceErrArr for storing ids which are already deleted or not found.
    * confirmMessageError and confirmMessageSuccess fields are showing success and error messages.
-   * 
+   *
    */
 
   triggerConfirm() {
@@ -280,11 +280,11 @@ export class ResourcesListComponent implements OnInit, OnDestroy {
     this.delResource.nativeElement.click();
     let d = 0;
     this.selectedResources.forEach((element, index) => {
-      var id = this.resourceService.deleteResourcePromise(element.resourceId).then((resp) => {  
+      var id = this.resourceService.deleteResourcePromise(element.resourceId).then((resp) => {
         this.successCount++;
         this.progressBar(index++, {resource:this.resources.filter(a => a.resourceId === element.resourceId)[0], error: false});
 
-      })  
+      })
       .catch(err => {
         this.failedResources.push(element.resourceId);
         this.progressBar(index++, {resource:this.resources.filter(a => a.resourceId === element.resourceId)[0], error: false});

--- a/src/app/_services/spinner/spinner.service.spec.ts
+++ b/src/app/_services/spinner/spinner.service.spec.ts
@@ -1,7 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-
 import { SpinnerService } from './spinner.service';
-import { doesNotReject } from 'assert';
 
 describe('SpinnerService', () => {
   let service: SpinnerService;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
     <a href="admin">Admin</a>
     <!-- end:Product Navigation -->
   </nav>
-    <div  id="stage">
+    <div id="stage"[ngClass]="{'spinner-overlay' : isLoading}">
       <!-- Accessibility: [role="main"] must be present on main#content -->
       <main style="min-height: 1000px;" role="main" id="content">
         <hx-panel class="hxSpan-12-xs">
@@ -16,7 +16,6 @@
             type="error">
               {{message}}
             </hx-alert>
-            <div class="spinner-overlay" *ngIf="isLoading"></div>
             <hx-busy class="gbl-spinner-show" *ngIf="isLoading"></hx-busy>
             <router-outlet></router-outlet>
           </hx-panelbody>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,6 +6,7 @@ a.editclick {
 .required {
     color: #d32f2f;
 }
+
 hx-busy.gbl-spinner-show {
     position: absolute !important;
     width: 2em;
@@ -18,7 +19,7 @@ hx-busy.gbl-spinner-show {
     transform-origin: unset;
 }
 .spinner-overlay {
-    position: fixed !important;
+    pointer-events: none;
     left: 0;
     top: 0;
     width: 100%;

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,5 @@
     <pilot-nav></pilot-nav>
   </header>
   <app-root></app-root>
-
-  <a id="bottom"></a>
 </body>
 </html>


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-599

 ## Description:
Resize overlay so that if a request timeouts the entire application is not blocked. Only the main app, the user should still have the ability to navigate.

 ## Testing:
Navigate to the Resources or Monitors.
Click sorting icon
Notice that clicking on navigation elements is still possible

 ## Screenshots:
![overlayResize](https://user-images.githubusercontent.com/5041718/98621167-49194e00-22cc-11eb-8080-6d8886a1d688.gif)
