### PR TITLE
Visualize route mnrva 711

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -24,8 +24,8 @@ const routes: Routes = [
       breadcrumb: 'ADMIN'
     }, resolve: {schema: SchemaResolver }
   },
-  { path: '', redirectTo: '/resources', pathMatch: 'full'},
-  { path: '**', redirectTo: '/resources'}
+  { path: '', redirectTo: '/visualize', pathMatch: 'full'},
+  { path: '**', redirectTo: '/visualize'}
 ];
 
 @NgModule({


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-711

 ## Description:
Added default route of Visualize, meaning when the app is loaded the visualize route will be shown to users. 

 ## Testing:
Navigate to app 
The default route should be `/visualize`

 ## Screenshots:
![image](https://user-images.githubusercontent.com/5041718/109176694-aedef800-774c-11eb-81b4-74cbd5e11ff6.png)
