### PR TITLE
Implement Flagging service for features no longer being used

### DIFF
--- a/env/environment.mock.ts
+++ b/env/environment.mock.ts
@@ -27,7 +27,11 @@ export const environment = {
     disallowLabelEdit: 'agent_'
   },
   featureFlags:{
-    adminAccess:false
+    admin:false,
+    adminAccess:false,
+    monitors: false,
+    resources: false,
+    visualize: true,
   }
 };
 

--- a/env/environment.prod.ts
+++ b/env/environment.prod.ts
@@ -25,6 +25,10 @@ export const environment = {
     disallowLabelEdit: 'agent_'
   },
   featureFlags:{
-    adminAccess:true
+    adminAccess:true,
+    admin:false,
+    monitors: false,
+    resources: false,
+    visualize: true,
   }
 };

--- a/env/environment.ts
+++ b/env/environment.ts
@@ -27,7 +27,11 @@ export const environment = {
     disallowLabelEdit: 'agent_'
   },
   featureFlags:{
-    adminAccess:true
+    admin:true,
+    monitors: true,
+    resources: false,
+    visualize: true,
+
   }
 };
 

--- a/env/environment.ts
+++ b/env/environment.ts
@@ -27,8 +27,8 @@ export const environment = {
     disallowLabelEdit: 'agent_'
   },
   featureFlags:{
-    admin:true,
-    monitors: true,
+    admin:false,
+    monitors: false,
     resources: false,
     visualize: true,
 

--- a/projects/admin/src/app/_services/tenant/impersonation.service.spec.ts
+++ b/projects/admin/src/app/_services/tenant/impersonation.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs/internal/observable/of';
 import { EnvironmentConfig } from 'src/app/_services/config/environmentConfig.service';
-import { ImpersonationToken } from '../_model/impersonationModel';
+import { ImpersonationToken } from '../../_model/impersonationModel';
 
 import { ImpersonationService } from './impersonation.service';
 

--- a/src/app/_guards/feature-flag.guard.spec.ts
+++ b/src/app/_guards/feature-flag.guard.spec.ts
@@ -1,9 +1,8 @@
 import { HttpClientModule } from '@angular/common/http';
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, ActivatedRoute, Route } from '@angular/router';
+import { Router, RouterStateSnapshot } from '@angular/router';
 import { FeatureFlag } from './feature-flag.guard';
-import { AppRoutingModule } from '../app.routing';
 
 class MockActivatedRouteSnapshot {
     private _data: any;
@@ -26,8 +25,7 @@ let mockRouterStateSnapshot : RouterStateSnapshot;
 
 describe('FeatureFlag', () => {
   let featureFlag: FeatureFlag;
-   let router: Router;
-  let authService;
+  let router: Router;
   let mockRouter: any;  
 
   beforeEach(() => {

--- a/src/app/_guards/feature-flag.guard.spec.ts
+++ b/src/app/_guards/feature-flag.guard.spec.ts
@@ -21,8 +21,6 @@ class MockActivatedRouteSnapshot {
   }
 ];
 
-let mockRouterStateSnapshot : RouterStateSnapshot;
-
 describe('FeatureFlag', () => {
   let featureFlag: FeatureFlag;
   let router: Router;

--- a/src/app/_guards/feature-flag.guard.spec.ts
+++ b/src/app/_guards/feature-flag.guard.spec.ts
@@ -1,0 +1,55 @@
+import { HttpClientModule } from '@angular/common/http';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, ActivatedRoute, Route } from '@angular/router';
+import { FeatureFlag } from './feature-flag.guard';
+import { AppRoutingModule } from '../app.routing';
+
+class MockActivatedRouteSnapshot {
+    private _data: any;
+    get data(){
+       return this._data;
+    }
+  }
+
+  const routes = [
+   { 
+    path: 'resources', 
+    loadChildren: () => import('../_features/resources/resources.module').then(m => m.ResourcesModule),
+    data: {
+      featureFlag: 'resources'
+    }
+  }
+];
+
+let mockRouterStateSnapshot : RouterStateSnapshot;
+
+describe('FeatureFlag', () => {
+  let featureFlag: FeatureFlag;
+   let router: Router;
+  let authService;
+  let mockRouter: any;  
+
+  beforeEach(() => {
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        RouterTestingModule.withRoutes(routes)
+      ],
+      providers: [
+        FeatureFlag
+      ]
+    });
+    featureFlag = TestBed.get(FeatureFlag);
+    router = TestBed.get(Router);
+
+  });
+
+
+  it('should be created', () => {
+    featureFlag = new FeatureFlag(mockRouter);
+    expect(featureFlag).toBeTruthy();
+  });
+});

--- a/src/app/_guards/feature-flag.guard.spec.ts
+++ b/src/app/_guards/feature-flag.guard.spec.ts
@@ -1,7 +1,8 @@
+import {Location} from "@angular/common";
 import { HttpClientModule } from '@angular/common/http';
-import { TestBed } from '@angular/core/testing';
+import { TestBed, getTestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Router, RouterStateSnapshot } from '@angular/router';
+import { Router } from '@angular/router';
 import { FeatureFlag } from './feature-flag.guard';
 
 class MockActivatedRouteSnapshot {
@@ -24,7 +25,10 @@ class MockActivatedRouteSnapshot {
 describe('FeatureFlag', () => {
   let featureFlag: FeatureFlag;
   let router: Router;
-  let mockRouter: any;  
+  let mockRouter: any;
+  let location: Location;
+  let injector: TestBed;
+  
 
   beforeEach(() => {
     mockRouter = jasmine.createSpyObj('Router', ['navigate']);
@@ -38,14 +42,21 @@ describe('FeatureFlag', () => {
         FeatureFlag
       ]
     });
-    featureFlag = TestBed.get(FeatureFlag);
-    router = TestBed.get(Router);
+
+    injector = getTestBed();
+    featureFlag = injector.inject(FeatureFlag);
+    router = injector.inject(Router);
+    location = injector.inject(Location);
 
   });
-
 
   it('should be created', () => {
     featureFlag = new FeatureFlag(mockRouter);
     expect(featureFlag).toBeTruthy();
   });
+
+  it('if resource flag is false, user not able to load module', () => {
+    router.navigateByUrl('resources');
+    expect(location.path()).toBe('');
+  }); 
 });

--- a/src/app/_guards/feature-flag.guard.ts
+++ b/src/app/_guards/feature-flag.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@angular/core";
+import { CanLoad, Route } from "@angular/router";
+import { FeatureFlagService } from "src/app/_services/features/featureFlag.service";
+import { EnvironmentConfig } from '../_services/config/environmentConfig.service';
+@Injectable()
+export class FeatureFlag implements CanLoad {
+
+  constructor(private featureFlagService: FeatureFlagService, private env: EnvironmentConfig ) { }
+    canLoad(route: Route):  Promise<boolean> | boolean {
+        // Get the name of the feature flag from the route data provided
+        const featureFlag = route.data['featureFlag'];
+        if (featureFlag) {
+            return this.featureFlagService.featureOn(featureFlag);
+        }
+        else {
+            return true;
+        }
+    }
+}

--- a/src/app/_guards/feature-flag.guard.ts
+++ b/src/app/_guards/feature-flag.guard.ts
@@ -1,16 +1,15 @@
 import { Injectable } from "@angular/core";
 import { CanLoad, Route } from "@angular/router";
-import { FeatureFlagService } from "src/app/_services/features/featureFlag.service";
 import { EnvironmentConfig } from '../_services/config/environmentConfig.service';
 @Injectable()
 export class FeatureFlag implements CanLoad {
 
-  constructor(private featureFlagService: FeatureFlagService, private env: EnvironmentConfig ) { }
+  constructor(private env: EnvironmentConfig ) { }
     canLoad(route: Route):  Promise<boolean> | boolean {
         // Get the name of the feature flag from the route data provided
         const featureFlag = route.data['featureFlag'];
         if (featureFlag) {
-            return this.featureFlagService.featureOn(featureFlag);
+            return this.env.featureFlags[featureFlag]
         }
         else {
             return true;

--- a/src/app/_services/config/environmentConfig.service.spec.ts
+++ b/src/app/_services/config/environmentConfig.service.spec.ts
@@ -25,7 +25,7 @@ describe('Feature and Environment Config', () => {
 
     it('should Load Feature Flag', (done)=>{
         featConf.loadEnvironment();
-        expect(featConf.featureFlags.adminAccess).toBe(env.featureFlags.adminAccess);
+        expect(featConf.featureFlags.admin).toBe(env.featureFlags.admin);
         done();
     })
 

--- a/src/app/_services/features/featureFlag.service.spec.ts
+++ b/src/app/_services/features/featureFlag.service.spec.ts
@@ -35,7 +35,7 @@ describe('Feature and Environment Config', () => {
 
       it('should return false if feature is off', () => {
         let featureName = 'resources';
-        expect(featFlagService.featureOn(featureName)).toBe(false);
+        expect(featFlagService.featureOn(featureName)).toBe(env.featureFlags[featureName]);
       });
 
 });

--- a/src/app/_services/features/featureFlag.service.spec.ts
+++ b/src/app/_services/features/featureFlag.service.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed, getTestBed } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { APP_INITIALIZER } from '@angular/core';
+import { FeatureFlagService } from './featureFlag.service';
+import { envConfig, EnvironmentConfig } from '../config/environmentConfig.service';
+
+
+
+describe('Feature and Environment Config', () => {
+    let featFlagService: FeatureFlagService;
+    let injector: TestBed;
+    let env: EnvironmentConfig;
+  
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [
+            HttpClientModule
+          ],
+          providers: [
+            FeatureFlagService,
+            {
+              provide: APP_INITIALIZER,
+              useFactory: envConfig,
+              deps: [ EnvironmentConfig ],
+              multi: true
+            }
+          ],
+    
+        });
+        injector = getTestBed();
+        featFlagService = injector.inject(FeatureFlagService);
+        env= injector.inject(EnvironmentConfig);
+
+      });
+
+      it('should return false if feature is off', () => {
+        let featureName = 'resources';
+        expect(featFlagService.featureOn(featureName)).toBe(false);
+      });
+
+});
+

--- a/src/app/_services/features/featureFlag.service.ts
+++ b/src/app/_services/features/featureFlag.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, Injector } from '@angular/core';
+import { EnvironmentConfig } from "../config/environmentConfig.service";
+
+@Injectable()
+export class FeatureFlagService {
+
+    constructor(private env: EnvironmentConfig) { }
+  featureOff(featureName: string) {
+    // Read the value from the config service
+    if (this.env.featureFlags.hasOwnProperty(featureName)) {
+        return !this.env.featureFlags[featureName];
+    }
+    return true; // if feature not found, default to turned off
+  }
+
+  featureOn(featureName: string) {
+    return !this.featureOff(featureName);
+  }
+}

--- a/src/app/_services/features/featureFlag.service.ts
+++ b/src/app/_services/features/featureFlag.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { EnvironmentConfig } from "../config/environmentConfig.service";
 
 @Injectable()

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,10 @@
 <div>
   <nav style="display: flex; width: 100%; padding:0;" id="nav" class="hxNav">
     <!-- Product Navigation -->
-    <a [routerLink]="'/resources'" href="">Resources</a>
-    <a [routerLink]="'/monitors'">Monitoring</a>
-    <a [routerLink]="'/visualize'">Visualize</a>
-    <a [routerLink]="'/admin'">Admin</a>
+    <a [routerLink]="'/resources'" *ngIf="featureFlag.featureOn('resources')">Resources</a>
+    <a [routerLink]="'/monitors'" *ngIf="featureFlag.featureOn('monitors')">Monitoring</a>
+    <a [routerLink]="'/visualize'" *ngIf="featureFlag.featureOn('visualize')">Visualize</a>
+    <a [routerLink]="'/admin'" *ngIf="featureFlag.featureOn('admin')">Admin</a>
     <!-- end:Product Navigation -->
   </nav>
     <div id="stage"[ngClass]="{'spinner-overlay' : isLoading}">

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,6 +4,7 @@ import { AppComponent } from './app.component';
 import { HttpClientModule } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FeatureFlagService } from 'src/app/_services/features/featureFlag.service';
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
@@ -17,6 +18,9 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      providers: [
+        FeatureFlagService
+      ]
     }).compileComponents();
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
+import { EnvironmentConfig, FeatureFlags } from 'src/app/_services/config/environmentConfig.service';
+import { FeatureFlagService } from 'src/app/_services/features/featureFlag.service';
 import { LoggingService } from './_services/logging/logging.service';
 import { SpinnerService } from './_services/spinner/spinner.service';
 
@@ -12,7 +14,8 @@ export class AppComponent implements OnInit  {
   message: string = undefined;
   isLoading: boolean;
   constructor(private lgService:LoggingService,
-     private changeDetector: ChangeDetectorRef, private spnService:SpinnerService){
+     private changeDetector: ChangeDetectorRef, private spnService:SpinnerService,
+     private featureFlag: FeatureFlagService){
 
      }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
-import { EnvironmentConfig, FeatureFlags } from 'src/app/_services/config/environmentConfig.service';
 import { FeatureFlagService } from 'src/app/_services/features/featureFlag.service';
 import { LoggingService } from './_services/logging/logging.service';
 import { SpinnerService } from './_services/spinner/spinner.service';
@@ -8,6 +7,8 @@ import { SpinnerService } from './_services/spinner/spinner.service';
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
+  providers: [FeatureFlagService]
+
 })
 
 export class AppComponent implements OnInit  {
@@ -15,7 +16,7 @@ export class AppComponent implements OnInit  {
   isLoading: boolean;
   constructor(private lgService:LoggingService,
      private changeDetector: ChangeDetectorRef, private spnService:SpinnerService,
-     private featureFlag: FeatureFlagService){
+     public featureFlag: FeatureFlagService){
 
      }
 

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -5,23 +5,27 @@ import { SchemaResolver } from './_features/monitors/monitor.resolve';
 const routes: Routes = [
   { path: 'resources', loadChildren: () => import('./_features/resources/resources.module').then(m => m.ResourcesModule),
     data: {
-      breadcrumb: 'RESOURCES'
+      breadcrumb: 'RESOURCES',
+      featureFlag: 'resources'
     }
   },
   { path: 'monitors', loadChildren: () => import('./_features/monitors/monitors.module').then(m => m.MonitorsModule),
     data: {
-      breadcrumb: 'MONITORS'
+      breadcrumb: 'MONITORS',
+      featureFlag: 'monitors'
     }, resolve: {schema: SchemaResolver }
   },
   { path: 'visualize', loadChildren: () => import('./_features/visualize/visualize.module').then(m => m.VisualizeModule),
     data: {
-      breadcrumb: 'VISUALIZE'
+      breadcrumb: 'VISUALIZE',
+      featureFlag: 'visualize'
     }
   },
   {
     path:'admin', loadChildren:() => import('projects/admin/src/app/app.module').then(m =>m.AppModule),
     data: {
-      breadcrumb: 'ADMIN'
+      breadcrumb: 'ADMIN',
+      featureFlag: 'admin'
     }, resolve: {schema: SchemaResolver }
   },
   { path: '', redirectTo: '/resources', pathMatch: 'full'},

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,15 +1,18 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { SchemaResolver } from './_features/monitors/monitor.resolve';
+import { FeatureFlag } from '../app/_guards/feature-flag.guard';
 
 const routes: Routes = [
   { path: 'resources', loadChildren: () => import('./_features/resources/resources.module').then(m => m.ResourcesModule),
+    canLoad : [FeatureFlag],
     data: {
       breadcrumb: 'RESOURCES',
       featureFlag: 'resources'
     }
   },
   { path: 'monitors', loadChildren: () => import('./_features/monitors/monitors.module').then(m => m.MonitorsModule),
+    canLoad : [FeatureFlag],
     data: {
       breadcrumb: 'MONITORS',
       featureFlag: 'monitors'
@@ -23,6 +26,7 @@ const routes: Routes = [
   },
   {
     path:'admin', loadChildren:() => import('projects/admin/src/app/app.module').then(m =>m.AppModule),
+    canLoad : [FeatureFlag],
     data: {
       breadcrumb: 'ADMIN',
       featureFlag: 'admin'


### PR DESCRIPTION
**JIRA:**
See ticket here - https://jira.rax.io/browse/MNRVA-728

**Description:**

1) Create feature service and guard.
2) Call guard using canLoad property of routing which actually prevent any user to call route which is off.
3) Configure flags inside environment file and calling those into guard.

**Testing:**

`npm run test:unit`

**Screenshots:**
<img width="1792" alt="Screenshot 2021-03-09 at 6 11 33 PM" src="https://user-images.githubusercontent.com/66314110/110472006-d77ad080-8102-11eb-8b1f-dfaa50115080.png">

(if applicable)