### PR TITLE
Hedwig component mnrva 761

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11555,8 +11555,8 @@
       "dev": true
     },
     "hedwig-monitoring-library": {
-      "version": "https://github.com/racker/Hedwig/archive/refs/tags/0.0.3.tar.gz",
-      "integrity": "sha512-zVlTG1k4y/2Y6uoKmOzxi1vfWwi9Edc68NZoHoeal4qe8x4DiT5M2l4jsOZeuDIL1i83yNLpdEFXW67yzcRXZQ==",
+      "version": "https://github.com/racker/Hedwig/archive/refs/tags/0.0.4.tar.gz",
+      "integrity": "sha512-HZJQuHpblq20pMP1Qh5JL4sIp6ctbwwg45+Jv8cmqQW6udCZUWzeW1Q3bWK+HaBABvrNKghD6txZb7lUpaPVtQ==",
       "requires": {
         "@webcomponents/webcomponentsjs": "2.2.1",
         "d3": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ajv": "6.12.0",
     "core-js": "2.5.4",
     "firebase": "8.1.2",
-    "hedwig-monitoring-library": "https://github.com/racker/Hedwig/archive/refs/tags/0.0.3.tar.gz",
+    "hedwig-monitoring-library": "https://github.com/racker/Hedwig/archive/refs/tags/0.0.4.tar.gz",
     "helix-ui": "1.1.0-rc.0",
     "jasmine-data-provider": "2.2.0",
     "moment": "2.24.0",

--- a/src/app/_features/visualize/components/graphs/graphs.component.html
+++ b/src/app/_features/visualize/components/graphs/graphs.component.html
@@ -1,3 +1,2 @@
-<p>
-  graphs works!
-</p>
+<app-hedwig-graph fieldName="usage_average" width="300" height="600"
+type="MAAS_cpu" [data]="data" ></app-hedwig-graph>

--- a/src/app/_features/visualize/components/graphs/graphs.component.ts
+++ b/src/app/_features/visualize/components/graphs/graphs.component.ts
@@ -7,9 +7,34 @@ import { Component, OnInit } from '@angular/core';
 })
 export class GraphsComponent implements OnInit {
 
+  data: any;
   constructor() { }
 
   ngOnInit() {
+    this.data = JSON.stringify([{
+      mean: 0.99,
+      time: "2018-11-24T18:58:21Z"
+    },
+    {
+      mean: 0.67,
+      time: "2018-11-25T23:58:21Z"
+    },
+    {
+      mean: 0.33,
+      time: "2018-11-26T02:58:21Z"
+    },
+    {
+      mean: 0.45,
+      time: "2018-11-27T18:58:21Z"
+    },
+    {
+      mean: 0.10,
+      time: "2018-11-28T23:58:21Z"
+    },
+    {
+      mean: 0.89,
+      time: "2018-11-29T02:58:21Z"
+  }]);
   }
 
 }

--- a/src/app/_shared/components/hedwig-graph/hedwig-graph.component.html
+++ b/src/app/_shared/components/hedwig-graph/hedwig-graph.component.html
@@ -1,0 +1,4 @@
+<hedwig-graph [attr.data-type]="type" [attr.data-field]="fieldName"
+[attr.data-height]="height" [attr.data-width]="width"
+[attr.data-graph]='data'>
+</hedwig-graph>

--- a/src/app/_shared/components/hedwig-graph/hedwig-graph.component.spec.ts
+++ b/src/app/_shared/components/hedwig-graph/hedwig-graph.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HedwigGraphComponent } from './hedwig-graph.component';
+import { LineGraph } from 'hedwig-monitoring-library';
+
+describe('HedwigGraphComponent', () => {
+  let component: HedwigGraphComponent;
+  let fixture: ComponentFixture<HedwigGraphComponent>;
+  let spy: any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HedwigGraphComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HedwigGraphComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should setup defaults', () => {
+    expect(component.fieldName).toBeUndefined();
+    expect(component.height).toBeUndefined();
+    expect(component.width).toBeUndefined();
+    expect(component.type).toBeUndefined();
+    expect(component.data).toBeUndefined();
+    expect(component.lineGraph).toEqual(LineGraph);
+  });
+
+
+  /**
+   * TODO: Test whether this.lineGraph() is instantiated
+  it('should execute LineGraph() class', () => {
+    spy = spyOn(component, 'lineGraph');
+    new HedwigGraphComponent();
+    expect(spy).toHaveBeenCalled();
+  });
+  */
+});

--- a/src/app/_shared/components/hedwig-graph/hedwig-graph.component.ts
+++ b/src/app/_shared/components/hedwig-graph/hedwig-graph.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { LineGraph } from 'hedwig-monitoring-library';
+
+
+/**
+ * To use the component add like so:
+ * <app-hedwig-graph fieldName="usage_average" width="300" height="600"
+type="MAAS_cpu" [data]="data"></app-hedwig-graph>
+ */
+
+@Component({
+  selector: 'app-hedwig-graph',
+  templateUrl: './hedwig-graph.component.html',
+  styleUrls: ['./hedwig-graph.component.scss']
+})
+export class HedwigGraphComponent implements OnInit {
+
+
+  @Input() fieldName: string;
+  @Input() width: number;
+  @Input() height: number;
+  @Input() type: string;
+  @Input() data: string;
+
+  lineGraph: LineGraph = LineGraph;
+
+  constructor() {  }
+
+  ngOnInit(): void {
+    new this.lineGraph();
+  }
+}

--- a/src/app/_shared/shared.module.ts
+++ b/src/app/_shared/shared.module.ts
@@ -15,6 +15,7 @@ import { AddFieldsComponent } from './components/add-fields/add-fields.component
 import { DurationSecondsPipe } from './pipes/duration-seconds.pipe';
 import { mockResourcesProvider } from '../_interceptors/request.interceptor';
 import { ZeroResultsComponent } from './components/zero-results/zero-results.component';
+import { HedwigGraphComponent } from './components/hedwig-graph/hedwig-graph.component';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
@@ -26,7 +27,8 @@ import { ZeroResultsComponent } from './components/zero-results/zero-results.com
     DurationSecondsPipe,
     MeasurementNamePipe,
     AddFieldsComponent,
-    ZeroResultsComponent
+    ZeroResultsComponent,
+    HedwigGraphComponent
   ],
   imports: [
     CommonModule,
@@ -47,7 +49,8 @@ import { ZeroResultsComponent } from './components/zero-results/zero-results.com
     MeasurementNamePipe,
     DeviceNamePipe,
     DurationSecondsPipe,
-    ZeroResultsComponent
+    ZeroResultsComponent,
+    HedwigGraphComponent
   ],
   providers: [
     { provide: ErrorHandler, useClass: GlobalErrorHandler },


### PR DESCRIPTION
## JIRA:
See ticket here - https://jira.rax.io/browse/MNRVA-761

 ## Description:
Add component for using Hedwig graphs - the component will be the single source of truth for the importing of the library. All instances of a graph will be using this component.


 ## Testing:
 - Once on _visualize_ view there will be a graph in the right column
 - `<hedwig-graph>` element will be present 

 ## Screenshots:
![image](https://user-images.githubusercontent.com/5041718/117024273-7402be80-acbf-11eb-953f-eaa7ca7499d7.png)
